### PR TITLE
Boss items, progressive items, and more

### DIFF
--- a/open_dread_rando/boss_powerup_template.lua
+++ b/open_dread_rando/boss_powerup_template.lua
@@ -1,0 +1,9 @@
+
+local original_TEMPLATE("funcname") = TEMPLATE("scenario").TEMPLATE("funcname")
+function TEMPLATE("scenario").TEMPLATE("funcname")(TEMPLATE("args"))
+    Game.LogWarn(0, "Starting boss callback")
+    original_TEMPLATE("funcname")(TEMPLATE("args"))
+    Game.LogWarn(0, "Granting item")
+    TEMPLATE("pickup_class").OnPickedUp(nil)
+    Game.LogWarn(0, "Item granted")
+end

--- a/open_dread_rando/custom_init.lua
+++ b/open_dread_rando/custom_init.lua
@@ -13,6 +13,7 @@ local buff = {}
 
 function Game.StartPrologue(arg1, arg2, arg3, arg4, arg4)
     Game.LogWarn(0, string.format("Will start Game - %s / %s / %s / %s", tostring(arg1), tostring(arg2), tostring(arg3), tostring(arg4)))
+    Game.SetForceSkipCutscenes(true)
     Game.LoadScenario("c10_samus", TEMPLATE("starting_scenario"), TEMPLATE("starting_actor"), "", 1)
 end
 

--- a/open_dread_rando/custom_init.lua
+++ b/open_dread_rando/custom_init.lua
@@ -1,8 +1,6 @@
 Game.ImportLibrary("system/scripts/original_init.lua")
 
-Init.tNewGameInventory = {
-    TEMPLATE("new_game_inventory")
-}
+Init.tNewGameInventory = TEMPLATE("new_game_inventory")
 
 Game.LogWarn(0, "Inventory:")
 for k, v in pairs(Init.tNewGameInventory) do
@@ -13,8 +11,8 @@ local buff = {}
 
 function Game.StartPrologue(arg1, arg2, arg3, arg4, arg4)
     Game.LogWarn(0, string.format("Will start Game - %s / %s / %s / %s", tostring(arg1), tostring(arg2), tostring(arg3), tostring(arg4)))
-    Game.SetForceSkipCutscenes(true)
     Game.LoadScenario("c10_samus", TEMPLATE("starting_scenario"), TEMPLATE("starting_actor"), "", 1)
 end
 
+Game.SetForceSkipCutscenes(true)
 Game.LogWarn(0, "Finished modded system/init.lc")

--- a/open_dread_rando/randomizer_powerup.lua
+++ b/open_dread_rando/randomizer_powerup.lua
@@ -1,34 +1,40 @@
-local suit_ids = {
-    "ITEM_VARIA_SUIT": true,
-    "ITEM_GRAVITY_SUIT": true,
-    "ITEM_HYPER_SUIT": true,
-}
+Game.LogWarn(0, "Loading randomizer_powerup.lua...")
 
+RandomizerPowerup = {}
 function RandomizerPowerup.main()
 end
-function RandomizerPowerup:OnPickedUp()
-    local granted = self:ProgressivePickup()
-    if suit_ids[granted] then
-        self.ChangeSuit()
-    end
+
+RandomizerPowerup.Self = nil
+
+function RandomizerPowerup.OnPickedUp(actor, progression)
+    RandomizerPowerup.Self = actor
+    Game.LogWarn(0, "Collected pickup: " .. actor.sName)
+    local granted = RandomizerPowerup.ProgressivePickup(progression)
+    RandomizerPowerup.ChangeSuit()
     return granted
 end
-function RandomizerPowerup:Progression()
-    return {}
-end
 
-function RandomizerPowerup:ProgressivePickup()
-    local progression = self:Progression()
-    if table.getn(progression) == 0 then
+function RandomizerPowerup.ProgressivePickup(progression)
+    progression = progression or {}
+
+    if #progression == 0 then
         return nil
-    elseif table.getn(progression) == 1 then
+    elseif #progression == 1 then
         return progression[0].item_id
     end
 
-    for _, resource in progression:ipairs() do
-        local current = Game.GetPlayer().INVENTORY:GetItemAmount(resource.item_id)
+    local data = "Progression: "
+    for _, resource in ipairs(progression) do
+        data = data .. resource.item_id .. " (" .. resource.quantity .. ") / "
+    end
+    Game.LogWarn(0, data)
+
+    for _, resource in ipairs(progression) do
+        local current = Game.GetItemAmount(Game.GetPlayerName(), resource.item_id)
+        Game.LogWarn(0, resource.item_id .. ": " .. current)
         if current < resource.quantity then
-            Game.GetPlayer().INVENTORY:SetItemAmount(resource.item_id, current+resource.quantity, true)
+            Game.LogWarn(0, "Granting " .. resource.quantity .. " " .. resource.item_id)
+            Game.GetPlayer().INVENTORY:SetItemAmount(resource.item_id, current + resource.quantity, true)
             return resource.item_id
         end
     end
@@ -37,12 +43,14 @@ end
 function RandomizerPowerup.ChangeSuit()
     -- ordered by priority
     local suits = {
-        {"item": "ITEM_HYPER_SUIT":, "model": "Hyper"},
-        {"item": "ITEM_GRAVITY_SUIT", "model": "Gravity"},
-        {"item": "ITEM_VARIA_SUIT", "model": "Varia"},
+        {item = "ITEM_HYPER_SUIT", model = "Hyper"},
+        {item = "ITEM_GRAVITY_SUIT", model = "Gravity"},
+        {item = "ITEM_VARIA_SUIT", model = "Varia"},
     }
     for _, suit in ipairs(suits) do
-        if Game.GetPlayer().INVENTORY:GetItemAmount(suit.item) > 0 then
+        Game.LogWarn(0, "Checking " .. suit.model .. "Suit...")
+        if Game.GetItemAmount(Game.GetPlayerName(), suit.item) > 0 then
+            Game.LogWarn(0, "Found it.")
             Game.GetPlayer().MODELUPDATER.sModelAlias = suit.model
             Game.GetPlayer().MODELUPDATER:ForceUpdate()
             break
@@ -50,14 +58,15 @@ function RandomizerPowerup.ChangeSuit()
     end
 end
 
-local metatable = {}
-metatable.__index = RandomizerPowerup
+local mt = {}
+mt.__index = RandomizerPowerup
 
 -- Main PBs (always) + PB expansions (if required mains are disabled)
 RandomizerPowerBomb = {}
-setmetatable(RandomizerPowerBomb, metatable)
-function RandomizerPowerBomb:OnPickedUp()
-    local granted = RandomizerPowerup.OnPickedUp(self)
+setmetatable(RandomizerPowerBomb, mt)
+function RandomizerPowerBomb.OnPickedUp(actor, progression)
+    progression = progression or {item_id = "ITEM_WEAPON_POWER_BOMB_MAX"}
+    local granted = RandomizerPowerup.OnPickedUp(actor, progression)
     if granted == "ITEM_WEAPON_POWER_BOMB_MAX" then
         Game.GetPlayer().INVENTORY:SetItemAmount("ITEM_WEAPON_POWER_BOMB", 1, true)
     end

--- a/open_dread_rando/randomizer_powerup.lua
+++ b/open_dread_rando/randomizer_powerup.lua
@@ -8,7 +8,9 @@ RandomizerPowerup.Self = nil
 
 function RandomizerPowerup.OnPickedUp(actor, progression)
     RandomizerPowerup.Self = actor
-    Game.LogWarn(0, "Collected pickup: " .. actor.sName)
+    local name = "Boss"
+    if actor ~= nil then name = actor.sName end
+    Game.LogWarn(0, "Collected pickup: " .. name)
     local granted = RandomizerPowerup.ProgressivePickup(progression)
     RandomizerPowerup.ChangeSuit()
     return granted
@@ -16,11 +18,12 @@ end
 
 function RandomizerPowerup.ProgressivePickup(progression)
     progression = progression or {}
+    local loop = false
 
     if #progression == 0 then
         return nil
     elseif #progression == 1 then
-        return progression[0].item_id
+        loop = true
     end
 
     local data = "Progression: "
@@ -31,8 +34,7 @@ function RandomizerPowerup.ProgressivePickup(progression)
 
     for _, resource in ipairs(progression) do
         local current = Game.GetItemAmount(Game.GetPlayerName(), resource.item_id)
-        Game.LogWarn(0, resource.item_id .. ": " .. current)
-        if current < resource.quantity then
+        if loop or current < resource.quantity then
             Game.LogWarn(0, "Granting " .. resource.quantity .. " " .. resource.item_id)
             Game.GetPlayer().INVENTORY:SetItemAmount(resource.item_id, current + resource.quantity, true)
             return resource.item_id
@@ -47,23 +49,21 @@ function RandomizerPowerup.ChangeSuit()
         {item = "ITEM_GRAVITY_SUIT", model = "Gravity"},
         {item = "ITEM_VARIA_SUIT", model = "Varia"},
     }
+    local model_updater = Game.GetPlayer().MODELUPDATER
     for _, suit in ipairs(suits) do
-        Game.LogWarn(0, "Checking " .. suit.model .. "Suit...")
+        if suit.model == model_updater.sModelAlias then break end
         if Game.GetItemAmount(Game.GetPlayerName(), suit.item) > 0 then
-            Game.LogWarn(0, "Found it.")
-            Game.GetPlayer().MODELUPDATER.sModelAlias = suit.model
-            Game.GetPlayer().MODELUPDATER:ForceUpdate()
+            Game.LogWarn(0, "Updating suit to " .. suit.model)
+            model_updater.sModelAlias = suit.model
+            model_updater:ForceUpdate()
             break
         end
     end
 end
 
-local mt = {}
-mt.__index = RandomizerPowerup
-
 -- Main PBs (always) + PB expansions (if required mains are disabled)
 RandomizerPowerBomb = {}
-setmetatable(RandomizerPowerBomb, mt)
+setmetatable(RandomizerPowerBomb, {__index = RandomizerPowerup})
 function RandomizerPowerBomb.OnPickedUp(actor, progression)
     progression = progression or {item_id = "ITEM_WEAPON_POWER_BOMB_MAX"}
     local granted = RandomizerPowerup.OnPickedUp(actor, progression)

--- a/open_dread_rando/randomizer_powerup.lua
+++ b/open_dread_rando/randomizer_powerup.lua
@@ -1,10 +1,65 @@
+local suit_ids = {
+    "ITEM_VARIA_SUIT": true,
+    "ITEM_GRAVITY_SUIT": true,
+    "ITEM_HYPER_SUIT": true,
+}
+
 function RandomizerPowerup.main()
 end
 function RandomizerPowerup:OnPickedUp()
-    -- Nothing!
+    local granted = self:ProgressivePickup()
+    if suit_ids[granted] then
+        self.ChangeSuit()
+    end
+    return granted
 end
--- function RandomizerPowerup.ChangeSuit()
---   Game.GetPlayer().INVENTORY:SetItemAmount("ITEM_VARIA_SUIT", 1, true)
---   Game.GetPlayer().MODELUPDATER.sModelAlias = "Varia"
---   Game.GetPlayer().MODELUPDATER:ForceUpdate()
--- end
+function RandomizerPowerup:Progression()
+    return {}
+end
+
+function RandomizerPowerup:ProgressivePickup()
+    local progression = self:Progression()
+    if table.getn(progression) == 0 then
+        return nil
+    elseif table.getn(progression) == 1 then
+        return progression[0].item_id
+    end
+
+    for _, resource in progression:ipairs() do
+        local current = Game.GetPlayer().INVENTORY:GetItemAmount(resource.item_id)
+        if current < resource.quantity then
+            Game.GetPlayer().INVENTORY:SetItemAmount(resource.item_id, current+resource.quantity, true)
+            return resource.item_id
+        end
+    end
+end
+
+function RandomizerPowerup.ChangeSuit()
+    -- ordered by priority
+    local suits = {
+        {"item": "ITEM_HYPER_SUIT":, "model": "Hyper"},
+        {"item": "ITEM_GRAVITY_SUIT", "model": "Gravity"},
+        {"item": "ITEM_VARIA_SUIT", "model": "Varia"},
+    }
+    for _, suit in ipairs(suits) do
+        if Game.GetPlayer().INVENTORY:GetItemAmount(suit.item) > 0 then
+            Game.GetPlayer().MODELUPDATER.sModelAlias = suit.model
+            Game.GetPlayer().MODELUPDATER:ForceUpdate()
+            break
+        end
+    end
+end
+
+local metatable = {}
+metatable.__index = RandomizerPowerup
+
+-- Main PBs (always) + PB expansions (if required mains are disabled)
+RandomizerPowerBomb = {}
+setmetatable(RandomizerPowerBomb, metatable)
+function RandomizerPowerBomb:OnPickedUp()
+    local granted = RandomizerPowerup.OnPickedUp(self)
+    if granted == "ITEM_WEAPON_POWER_BOMB_MAX" then
+        Game.GetPlayer().INVENTORY:SetItemAmount("ITEM_WEAPON_POWER_BOMB", 1, true)
+    end
+end
+

--- a/open_dread_rando/randomizer_powerup.lua
+++ b/open_dread_rando/randomizer_powerup.lua
@@ -13,6 +13,8 @@ function RandomizerPowerup.OnPickedUp(actor, progression)
     Game.LogWarn(0, "Collected pickup: " .. name)
     local granted = RandomizerPowerup.ProgressivePickup(progression)
     RandomizerPowerup.ChangeSuit()
+    RandomizerPowerup.IncreaseEnergy(granted)
+    -- Game.ReinitPlayerFromBlackboard()
     return granted
 end
 
@@ -61,11 +63,20 @@ function RandomizerPowerup.ChangeSuit()
     end
 end
 
+function RandomizerPowerup.IncreaseEnergy(item_id)
+    if item_id ~= "ITEM_ENERGY_TANKS" and item_id ~= "ITEM_LIFE_SHARDS" then return end
+    if item_id == "ITEM_LIFE_SHARDS" and (Game.GetItemAmount(Game.GetPlayerName(), item_id) % 4) ~= 0 then return end
+    Game.LogWarn(0, "Increasing player energy.")
+    local max = Game.GetItemAmount(Game.GetPlayerName(), "ITEM_MAX_LIFE")
+    Game.GetPlayer().INVENTORY:SetItemAmount("ITEM_MAX_LIFE", max+100, true)
+    Game.GetPlayer().INVENTORY:SetItemAmount("ITEM_CURRENT_LIFE", max+100, true)
+end
+
 -- Main PBs (always) + PB expansions (if required mains are disabled)
 RandomizerPowerBomb = {}
 setmetatable(RandomizerPowerBomb, {__index = RandomizerPowerup})
 function RandomizerPowerBomb.OnPickedUp(actor, progression)
-    progression = progression or {item_id = "ITEM_WEAPON_POWER_BOMB_MAX"}
+    progression = {{item_id = "ITEM_WEAPON_POWER_BOMB_MAX", quantity = 0}}
     local granted = RandomizerPowerup.OnPickedUp(actor, progression)
     if granted == "ITEM_WEAPON_POWER_BOMB_MAX" then
         Game.GetPlayer().INVENTORY:SetItemAmount("ITEM_WEAPON_POWER_BOMB", 1, true)

--- a/open_dread_rando/randomizer_progressive_template.lua
+++ b/open_dread_rando/randomizer_progressive_template.lua
@@ -1,0 +1,8 @@
+
+TEMPLATE("name") = {}
+setmetatable(TEMPLATE("name"), metatable)
+function TEMPLATE("name"):Progression()
+    return {
+        TEMPLATE("progression")
+    }
+end

--- a/open_dread_rando/randomizer_progressive_template.lua
+++ b/open_dread_rando/randomizer_progressive_template.lua
@@ -1,8 +1,11 @@
+Game.LogWarn(0, "loading TEMPLATE("name")")
 
-setmetatable(TEMPLATE("name"), mt)
+TEMPLATE("name") = {}
+setmetatable(TEMPLATE("name"), {__index = TEMPLATE("parent")})
 function TEMPLATE("name").main()
 end
 function TEMPLATE("name").OnPickedUp(actor)
+    Game.LogWarn(0, "picked up TEMPLATE("name")")
     local progression = TEMPLATE("progression")
-    RandomizerPowerup.OnPickedUp(actor, progression)
+    TEMPLATE("parent").OnPickedUp(actor, progression)
 end

--- a/open_dread_rando/randomizer_progressive_template.lua
+++ b/open_dread_rando/randomizer_progressive_template.lua
@@ -1,8 +1,8 @@
 
-TEMPLATE("name") = {}
-setmetatable(TEMPLATE("name"), metatable)
-function TEMPLATE("name"):Progression()
-    return {
-        TEMPLATE("progression")
-    }
+setmetatable(TEMPLATE("name"), mt)
+function TEMPLATE("name").main()
+end
+function TEMPLATE("name").OnPickedUp(actor)
+    local progression = TEMPLATE("progression")
+    RandomizerPowerup.OnPickedUp(actor, progression)
 end

--- a/open_dread_rando/schema.json
+++ b/open_dread_rando/schema.json
@@ -61,10 +61,14 @@
                         "pickup_actordef": {
                             "type": "string",
                             "pattern": "[a-zA-Z0-9_/]+?\\.bmsad"
+                        },
+                        "pickup_string_key": {
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "pickup_actordef"
+                        "pickup_actordef",
+                        "pickup_string_key"
                     ]
                 }
             }

--- a/open_dread_rando/schema.json
+++ b/open_dread_rando/schema.json
@@ -10,13 +10,16 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "pickup_actor": {
-                        "$ref": "#/$defs/actor_reference_with_layer"
+                    "pickup_type": {
+                        "type": "string",
+                        "enum": [
+                            "actor",
+                            "emmi",
+                            "corex",
+                            "corpius"
+                        ]
                     },
                     "caption": {
-                        "type": "string"
-                    },
-                    "model": {
                         "type": "string"
                     },
                     "item_id": {
@@ -27,12 +30,43 @@
                     }
                 },
                 "required": [
-                    "pickup_actor",
+                    "pickup_type",
                     "caption",
-                    "model",
                     "item_id",
                     "quantity"
-                ]
+                ],
+                "if": {
+                    "properties": {
+                        "pickup_type": {
+                            "const": "actor"
+                        }
+                    }
+                },
+                "then": {
+                    "properties": {
+                        "pickup_actor": {
+                            "$ref": "#/$defs/actor_reference_with_layer"
+                        },
+                        "model": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "pickup_actor",
+                        "model"
+                    ]
+                },
+                "else": {
+                    "properties": {
+                        "pickup_actordef": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9_/]+?\\.bmsad"
+                        }
+                    },
+                    "required": [
+                        "pickup_actordef"
+                    ]
+                }
             }
         },
         "elevators": {

--- a/open_dread_rando/schema.json
+++ b/open_dread_rando/schema.json
@@ -22,18 +22,29 @@
                     "caption": {
                         "type": "string"
                     },
-                    "item_id": {
-                        "type": "string"
-                    },
-                    "quantity": {
-                        "type": "number"
+                    "resources": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "item_id": {
+                                    "type": "string"
+                                },
+                                "quantity": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "item_id",
+                                "quantity"
+                            ]
+                        }
                     }
                 },
                 "required": [
                     "pickup_type",
                     "caption",
-                    "item_id",
-                    "quantity"
+                    "resources"
                 ],
                 "if": {
                     "properties": {

--- a/open_dread_rando/schema.json
+++ b/open_dread_rando/schema.json
@@ -7,6 +7,8 @@
         },
         "pickups": {
             "type": "array",
+            "minItems": 146,
+            "maxItems": 148,
             "items": {
                 "type": "object",
                 "properties": {
@@ -75,11 +77,15 @@
                         },
                         "pickup_string_key": {
                             "type": "string"
+                        },
+                        "pickup_lua_callback": {
+                            "$ref": "#/$defs/scenario_lua_callback"
                         }
                     },
                     "required": [
                         "pickup_actordef",
-                        "pickup_string_key"
+                        "pickup_string_key",
+                        "pickup_lua_callback"
                     ]
                 }
             }
@@ -111,6 +117,21 @@
         "starting_items"
     ],
     "$defs": {
+        "scenario_lua_callback": {
+            "type": "object",
+            "properties": {
+                "scenario": {
+                    "$ref": "#/$defs/scenario_name"
+                },
+                "function": {
+                    "type": "string"
+                },
+                "args": {
+                    "type": "number",
+                    "default": 0
+                }
+            }
+        },
         "actor_reference_with_layer": {
             "type": "object",
             "properties": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 [options]
 packages = open_dread_rando
 install_requires =
-    mercury-engine-data-structures>=0.9.4
+    mercury-engine-data-structures>=0.9.6
     jsonschema>=4.0.0
 
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 [options]
 packages = open_dread_rando
 install_requires =
-    mercury-engine-data-structures>=0.9.1
+    mercury-engine-data-structures>=0.9.4
     jsonschema>=4.0.0
 
 include_package_data = True


### PR DESCRIPTION
Fixes #1 
Fixes #2 
Fixes #3 
Fixes #7 
Fixes #9 (with the caveat that hyper suit/hyper beam pickup indices are not mandatory)

known issue: expansions/progressive items have some strange behavior on bosses still. I believe it's related to callbacks on closing the inventory screen that aren't going through properly. more investigation needed. examples include
 - emmizone darkness not being reset properly
 - softlocking on corpius from the "Upgrading suit for aeion compatibility" popup
 - possibly more

also, I've only tested corpius and artaria emmi. there may be issues on the other bosses, yet

also also: the code is ugly I'm sorry we really need to reorganize lmao