### PR TITLE
Fix a bug where the game would hard-save upon entering a new area for the first time

### DIFF
--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -43,11 +43,12 @@ function Scenario.EmmyAbilityObtained_ShowMessage(message, callback, finalcallba
     Game.AddSF(0.5, Game.PlayCurrentEnvironmentMusic, "")
 end
 
+Scenario.sRandoGameInitializedPropID = Blackboard.RegisterLUAProp("RANDO_GAME_INITIALIZED", "bool")
 local init_scenario = Scenario.InitScenario
 function Scenario.InitScenario(arg1, arg2, arg3, arg4)
     init_scenario(arg1, arg2, arg3, arg4)
-    if not Scenario.ReadFromBlackboard(Scenario.LUAPropIDs.CAVES_GAME_INTRO, false) then
-        Scenario.WriteToBlackboard(Scenario.LUAPropIDs.CAVES_GAME_INTRO, "b", true)
+    if not Scenario.ReadFromSharedBlackboard(Scenario.sRandoGameInitializedPropID, false) then
+        Scenario.WriteToSharedBlackboard(Scenario.sRandoGameInitializedPropID, "b", true)
         Game.AddSF(0.9, Init.SaveGameAtStartingLocation, "")
         Game.AddSF(0.8, Scenario.ShowText, "")
     end

--- a/open_dread_rando/files/levels/s010_cave.lc.lua
+++ b/open_dread_rando/files/levels/s010_cave.lc.lua
@@ -193,8 +193,8 @@ end
 function s010_cave.OnEnd_Cutscene_intro_end()
     
   
-  -- Scenario.WriteToBlackboard(Scenario.LUAPropIDs.CAVES_GAME_INTRO, "b", true)
-  -- CAVES_GAME_INTRO = true
+  Scenario.WriteToBlackboard(Scenario.LUAPropIDs.CAVES_GAME_INTRO, "b", true)
+  CAVES_GAME_INTRO = true
   Game.PushSetup("PostIntro", true, true)
   Game.PlayCurrentEnvironmentMusic()
   -- Game.SaveGame("savedata", "IntroEnd", "StartPoint0", true)


### PR DESCRIPTION
Fixes #58. The root cause of that issue is that the `custom_scenario.lua` script was reusing the `CAVES_INTRO_APPLIED` Blackboard prop to determine whether or not the game was "initialized", and doing so via the per-scenario Blackboard. This meant that any time the player loaded another scenario for the first time, `custom_scenario.lua` would re-initialize the game, resulting in a new "hard save" at that area's start location. It would also sometimes show the "Random Starting Items" message upon entering a new area, although this only happened sometimes in my own experience.

The fix is two-fold:

- Register a new Lua Blackboard prop that is specifically used to determine whether or not the rando code has been initialized
- Store this new prop in the Shared Blackboard instead of the per-Scenario blackboard so that the init code only runs _once_ at the start of the game as opposed to any time the player enters a new Scenario

I also restored the code in `s010_cave.lc.lua` to set the `CAVES_INTRO_APPLIED` flag, just to be safe. It doesn't appear to do anything drastic for Artaria with the entire intro cutscene disabled, but I figured it's best to make sure Artaria does in fact set that flag on its blackboard like the game expects. I didn't restore the code to save the game upon entering Artaria, so this should not regress the fix for #47.

I captured a video demonstrating that the save bug is fixed: https://youtu.be/A3p5Zx9IKKY
