### PR TITLE
Fix an issue created in #67 related to game saves and starting items

### DIFF
--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -43,12 +43,15 @@ function Scenario.EmmyAbilityObtained_ShowMessage(message, callback, finalcallba
     Game.AddSF(0.5, Game.PlayCurrentEnvironmentMusic, "")
 end
 
-Scenario.sRandoGameInitializedPropID = Blackboard.RegisterLUAProp("RANDO_GAME_INITIALIZED", "bool")
 local init_scenario = Scenario.InitScenario
 function Scenario.InitScenario(arg1, arg2, arg3, arg4)
     init_scenario(arg1, arg2, arg3, arg4)
-    if not Scenario.ReadFromSharedBlackboard(Scenario.sRandoGameInitializedPropID, false) then
-        Scenario.WriteToSharedBlackboard(Scenario.sRandoGameInitializedPropID, "b", true)
+
+    local playerSection =  Game.GetPlayerBlackboardSectionName()
+    local randoInitialized = Blackboard.GetProp(playerSection, "RANDO_GAME_INITIALIZED")
+
+    if not randoInitialized then
+        Blackboard.SetProp(playerSection, "RANDO_GAME_INITIALIZED", "b", true)
         Game.AddSF(0.9, Init.SaveGameAtStartingLocation, "")
         Game.AddSF(0.8, Scenario.ShowText, "")
     end


### PR DESCRIPTION
The fix implemented in #67 ended up being the wrong solution; apparently the "Shared Blackboard" (as the game calls it) persists across all game saves, but can reset randomly sometimes. It seems like it may be some sort of transient session blackboard or something.

After looking through some more of the game's own scripts, it seems like the "Player Blackboard" (called `PLAYER`, from `Game.GetPlayerBlackboardSectionName()`) has the correct scope and lifetime. I did some additional testing, and it does indeed cause the "starting items" message to be set on _each_ new game, but _only_ on a new game. Reloading to save, continuing a file, entering a new area, etc. all behave correctly now and do *NOT* create a new game save point.