### PR TITLE
Warn when loading a game that wasn't created on the current patch, and don't save over it

### DIFF
--- a/open_dread_rando/dread_patcher.py
+++ b/open_dread_rando/dread_patcher.py
@@ -31,6 +31,7 @@ def create_custom_init(editor: PatcherEditor, configuration: dict):
     inventory: dict[str, int] = configuration["starting_items"]
     starting_location: dict = configuration["starting_location"]
     starting_text: list[list[str]] = configuration.get("starting_text", [])
+    shareable_hash: str = configuration["shareable_hash"]
 
     energy_per_tank = configuration.get("energy_per_tank", 100)
     energy_per_part = configuration.get("energy_per_part", energy_per_tank / 4)
@@ -78,6 +79,7 @@ def create_custom_init(editor: PatcherEditor, configuration: dict):
         "energy_per_part": energy_per_part,
         "immediate_energy_parts": configuration.get("immediate_energy_parts", False),
         "default_x_released": configuration.get("game_patches", {}).get("default_x_released", False),
+        "shareable_hash": lua_util.wrap_string(shareable_hash),
     }
 
     return lua_util.replace_lua_template("custom_init.lua", replacement)

--- a/open_dread_rando/dread_patcher.py
+++ b/open_dread_rando/dread_patcher.py
@@ -31,7 +31,7 @@ def create_custom_init(editor: PatcherEditor, configuration: dict):
     inventory: dict[str, int] = configuration["starting_items"]
     starting_location: dict = configuration["starting_location"]
     starting_text: list[list[str]] = configuration.get("starting_text", [])
-    shareable_hash: str = configuration["shareable_hash"]
+    configuration_identifier: str = configuration["configuration_identifier"]
 
     energy_per_tank = configuration.get("energy_per_tank", 100)
     energy_per_part = configuration.get("energy_per_part", energy_per_tank / 4)
@@ -79,7 +79,7 @@ def create_custom_init(editor: PatcherEditor, configuration: dict):
         "energy_per_part": energy_per_part,
         "immediate_energy_parts": configuration.get("immediate_energy_parts", False),
         "default_x_released": configuration.get("game_patches", {}).get("default_x_released", False),
-        "shareable_hash": lua_util.wrap_string(shareable_hash),
+        "configuration_identifier": lua_util.wrap_string(configuration_identifier),
     }
 
     return lua_util.replace_lua_template("custom_init.lua", replacement)

--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -46,7 +46,15 @@ end
 local init_scenario = Scenario.InitScenario
 function Scenario.InitScenario(arg1, arg2, arg3, arg4)
     local playerSection =  Game.GetPlayerBlackboardSectionName()
+    local thisRandoHash = Blackboard.GetProp(playerSection, "THIS_RANDO_HASH")
     local randoInitialized = Blackboard.GetProp(playerSection, "RANDO_GAME_INITIALIZED")
+
+    -- Cross-check the seed hash in the Blackboard with the one in Init.sThisRandoSeedHash to make sure they match.
+    -- If they don't, show a warning to the player, and DO NOT save over their game!
+    if thisRandoHash ~= Init.sThisRandoSeedHash then
+        Game.AddSF(0.8, Scenario.ShowNotRandoGameMessage, "")
+        return
+    end
 
     if not randoInitialized then
         Game.SetXparasite(Init.bDefaultXRelease)
@@ -60,6 +68,16 @@ function Scenario.InitScenario(arg1, arg2, arg3, arg4)
         Game.AddSF(0.9, Init.SaveGameAtStartingLocation, "")
         Game.AddSF(0.8, Scenario.ShowText, "")
     end
+end
+
+local warning_messages_seen = 0
+local total_warning_messages = 2
+function Scenario.ShowNotRandoGameMessage()
+    warning_messages_seen = warning_messages_seen + 1
+    if warning_messages_seen > total_warning_messages then
+        return
+    end
+    GUI.ShowMessage("#GUI_WARNING_NOT_RANDO_GAME_" .. warning_messages_seen, true, "Scenario.ShowNotRandoGameMessage")
 end
 
 Scenario.sRandoStartingTextSeenPropID = Blackboard.RegisterLUAProp("RANDO_START_TEXT", "bool")

--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -46,14 +46,17 @@ end
 local init_scenario = Scenario.InitScenario
 function Scenario.InitScenario(arg1, arg2, arg3, arg4)
     local playerSection =  Game.GetPlayerBlackboardSectionName()
-    local currentSaveRandoHash = Blackboard.GetProp(playerSection, "THIS_RANDO_HASH")
+    local currentSaveRandoIdentifier = Blackboard.GetProp(playerSection, "THIS_RANDO_IDENTIFIER")
     local randoInitialized = Blackboard.GetProp(playerSection, "RANDO_GAME_INITIALIZED")
 
-    Game.LogWarn(0, ("Cross-checking seed hashes. The current patch's hash is %q, and the current save's hash is %q."):format(Init.sThisRandoSeedHash, tostring(currentSaveRandoHash)))
+    Game.LogWarn(0, string.format(
+            "Cross-checking seed hashes. The current patch's hash is %q, and the current save's hash is %q.",
+            Init.sThisRandoIdentifier, tostring(currentSaveRandoIdentifier)
+    ))
 
     -- Cross-check the seed hash in the Blackboard with the one in Init.sThisRandoSeedHash to make sure they match.
     -- If they don't, show a warning to the player, and DO NOT save over their game!
-    if currentSaveRandoHash ~= Init.sThisRandoSeedHash then
+    if currentSaveRandoIdentifier ~= Init.sThisRandoIdentifier then
         Game.AddSF(0.8, Scenario.ShowNotRandoGameMessage, "")
         return
     end

--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -80,6 +80,7 @@ local total_warning_messages = 2
 function Scenario.ShowNotRandoGameMessage()
     warning_messages_seen = warning_messages_seen + 1
     if warning_messages_seen > total_warning_messages then
+        Scenario.FadeOutAndGoToMainMenu(0.3)
         return
     end
     GUI.ShowMessage("#GUI_WARNING_NOT_RANDO_GAME_" .. warning_messages_seen, true, "Scenario.ShowNotRandoGameMessage")

--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -49,7 +49,7 @@ function Scenario.InitScenario(arg1, arg2, arg3, arg4)
     local currentSaveRandoHash = Blackboard.GetProp(playerSection, "THIS_RANDO_HASH")
     local randoInitialized = Blackboard.GetProp(playerSection, "RANDO_GAME_INITIALIZED")
 
-    Game.LogWarn(0, ("Cross-checking seed hashes. The current patch's hash is %q, and the current save's hash is %q."):format(Init.sThisRandoSeedHash, currentSaveRandoHash))
+    Game.LogWarn(0, ("Cross-checking seed hashes. The current patch's hash is %q, and the current save's hash is %q."):format(Init.sThisRandoSeedHash, tostring(currentSaveRandoHash)))
 
     -- Cross-check the seed hash in the Blackboard with the one in Init.sThisRandoSeedHash to make sure they match.
     -- If they don't, show a warning to the player, and DO NOT save over their game!

--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -46,12 +46,14 @@ end
 local init_scenario = Scenario.InitScenario
 function Scenario.InitScenario(arg1, arg2, arg3, arg4)
     local playerSection =  Game.GetPlayerBlackboardSectionName()
-    local thisRandoHash = Blackboard.GetProp(playerSection, "THIS_RANDO_HASH")
+    local currentSaveRandoHash = Blackboard.GetProp(playerSection, "THIS_RANDO_HASH")
     local randoInitialized = Blackboard.GetProp(playerSection, "RANDO_GAME_INITIALIZED")
+
+    Game.LogWarn(0, ("Cross-checking seed hashes. The current patch's hash is %q, and the current save's hash is %q."):format(Init.sThisRandoSeedHash, currentSaveRandoHash))
 
     -- Cross-check the seed hash in the Blackboard with the one in Init.sThisRandoSeedHash to make sure they match.
     -- If they don't, show a warning to the player, and DO NOT save over their game!
-    if thisRandoHash ~= Init.sThisRandoSeedHash then
+    if currentSaveRandoHash ~= Init.sThisRandoSeedHash then
         Game.AddSF(0.8, Scenario.ShowNotRandoGameMessage, "")
         return
     end

--- a/open_dread_rando/files/schema.json
+++ b/open_dread_rando/files/schema.json
@@ -6,6 +6,10 @@
             "type": "string",
             "format": "uri"
         },
+        "configuration_identifier": {
+            "type": "string",
+            "description": "An unique identifier for this configuration. Only save files created with this identifier can be loaded."
+        },
         "starting_location": {
             "$ref": "#/$defs/actor_reference"
         },
@@ -275,9 +279,6 @@
             "description": "When pkg, outputs fully modified pkg files. On romfs, output just the modified files but requires an exefs patch to load.",
             "default": "pkg"
         },
-        "shareable_hash": {
-            "type": "string"
-        },
         "cosmetic_patches": {
             "type": "object",
             "properties": {
@@ -351,6 +352,7 @@
         }
     },
     "required": [
+        "configuration_identifier",
         "starting_location",
         "starting_items",
         "pickups"

--- a/open_dread_rando/files/schema.json
+++ b/open_dread_rando/files/schema.json
@@ -275,6 +275,9 @@
             "description": "When pkg, outputs fully modified pkg files. On romfs, output just the modified files but requires an exefs patch to load.",
             "default": "pkg"
         },
+        "shareable_hash": {
+            "type": "string"
+        },
         "cosmetic_patches": {
             "type": "object",
             "properties": {

--- a/open_dread_rando/templates/custom_init.lua
+++ b/open_dread_rando/templates/custom_init.lua
@@ -29,7 +29,7 @@ function Init.SaveGameAtStartingLocation()
     Game.SaveGame("savedata", "IntroEnd", Init.sStartingActor, true)
 end
 
-Init.sThisRandoSeedHash = TEMPLATE("shareable_hash")
+Init.sThisRandoIdentifier = TEMPLATE("configuration_identifier")
 
 local original_Init_CreateNewGameData = Init.CreateNewGameData
 function Init.CreateNewGameData(difficulty)
@@ -38,17 +38,17 @@ function Init.CreateNewGameData(difficulty)
     local playerSection =  Game.GetPlayerBlackboardSectionName()
 
     --[[
-        When creating a new save file, store the current seed hash in the Blackboard.
+        When creating a new save file, store the current identifier in the Blackboard.
 
-        The seed hash will be cross-checked when loading a save (via Scenario.InitScenario), and a warning message will be shown if the
-        hash in the Blackboard doesn't exist or doesn't match the copy stored in Init.sThisRandoSeedHash.
+        The identifier will be cross-checked when loading a save (via Scenario.InitScenario), and a warning message will be shown if the
+        identifier in the Blackboard doesn't exist or doesn't match the copy stored in Init.sThisRandoIdentifier.
 
-        If the player loads a non-rando save, the hash won't exist in the Blackboard, and if they load a save from a different seed, the
-        hash in the Blackboard will be different than the one in Init.sThisRandoSeedHash.
+        If the player loads a non-rando save, the identifier won't exist in the Blackboard, and if they load a save from a different seed, the
+        hash in the Blackboard will be different than the one in Init.sThisRandoIdentifier.
     ]]
 
-    Game.LogWarn(0, ("Setting THIS_RANDO_HASH Blackboard property to %q"):format(Init.sThisRandoSeedHash))
-    Blackboard.SetProp(playerSection, "THIS_RANDO_HASH", "s", Init.sThisRandoSeedHash)
+    Game.LogWarn(0, string.format("Setting THIS_RANDO_IDENTIFIER Blackboard property to %q", Init.sThisRandoIdentifier))
+    Blackboard.SetProp(playerSection, "THIS_RANDO_IDENTIFIER", "s", Init.sThisRandoIdentifier)
 
     -- Must explicitly set the "initialized" flag to false; it seems the Player Blackboard doesn't get fully wiped when making a new file
     -- after recently playing a file in the same slot.

--- a/open_dread_rando/templates/custom_init.lua
+++ b/open_dread_rando/templates/custom_init.lua
@@ -47,7 +47,7 @@ function Init.CreateNewGameData(difficulty)
         hash in the Blackboard will be different than the one in Init.sThisRandoSeedHash.
     ]]
 
-    Game.LogWarn(0, "Setting THIS_RANDO_HASH Blackboard property")
+    Game.LogWarn(0, ("Setting THIS_RANDO_HASH Blackboard property to %q"):format(Init.sThisRandoSeedHash))
     Blackboard.SetProp(playerSection, "THIS_RANDO_HASH", "s", Init.sThisRandoSeedHash)
 
     -- Must explicitly set the "initialized" flag to false; it seems the Player Blackboard doesn't get fully wiped when making a new file

--- a/open_dread_rando/templates/custom_init.lua
+++ b/open_dread_rando/templates/custom_init.lua
@@ -29,6 +29,34 @@ function Init.SaveGameAtStartingLocation()
     Game.SaveGame("savedata", "IntroEnd", Init.sStartingActor, true)
 end
 
+Init.sThisRandoSeedHash = TEMPLATE("shareable_hash")
+
+local original_Init_CreateNewGameData = Init.CreateNewGameData
+function Init.CreateNewGameData(difficulty)
+    original_Init_CreateNewGameData(difficulty)
+
+    local playerSection =  Game.GetPlayerBlackboardSectionName()
+
+    --[[
+        When creating a new save file, store the current seed hash in the Blackboard.
+
+        The seed hash will be cross-checked when loading a save (via Scenario.InitScenario), and a warning message will be shown if the
+        hash in the Blackboard doesn't exist or doesn't match the copy stored in Init.sThisRandoSeedHash.
+
+        If the player loads a non-rando save, the hash won't exist in the Blackboard, and if they load a save from a different seed, the
+        hash in the Blackboard will be different than the one in Init.sThisRandoSeedHash.
+    ]]
+
+    Game.LogWarn(0, "Setting THIS_RANDO_HASH Blackboard property")
+    Blackboard.SetProp(playerSection, "THIS_RANDO_HASH", "s", Init.sThisRandoSeedHash)
+
+    -- Must explicitly set the "initialized" flag to false; it seems the Player Blackboard doesn't get fully wiped when making a new file
+    -- after recently playing a file in the same slot.
+
+    Game.LogWarn(0, "Resetting RANDO_GAME_INITIALIZED Blackboard property")
+    Blackboard.SetProp(playerSection, "RANDO_GAME_INITIALIZED", "b", false)
+end
+
 Game.SetForceSkipCutscenes(true)
 Game.LogWarn(0, "Finished modded system/init.lc")
 


### PR DESCRIPTION
**NOTE:** Requires randovania/randovania#3117 in order to work!

I added some sanity checking/cross-checking to the Init and Scenario scripts that will verify that the player is either A) starting a new game with the current patch, or B) loading a saved game that was created with the current patch. If the player loads a non-rando save file, or if they load one that was created from a different seed/patch, they will see a warning message informing them that the game will not work right.

This also makes the Scenario script skip saving the game at the "starting location" if the seed cross-check doesn't succeed, which will prevent the rando from overwriting a vanilla save file if a player accidentally loads one with rando enabled (I kept doing this on accident, forgetting that I had rando enabled from the night before, etc., and would end up with 3:46 speedrunning files that I had to re-create).