### PR TITLE
Fix core-x boss scripts when drop is just a single item

### DIFF
--- a/open_dread_rando/lua_editor.py
+++ b/open_dread_rando/lua_editor.py
@@ -19,12 +19,16 @@ SPECIFIC_CLASSES = {
     "ITEM_MULTILOCKON": "RandomizerStormMissile",
 }
 
+
 class LuaEditor:
     def __init__(self):
         self._progressive_classes = {}
         self._powerup_script = _read_powerup_lua()
         self._custom_level_scripts: dict[str, dict] = self._read_levels()
-        self._corex_replacement = {}
+        self._corex_replacement = {
+            "escue": "false",
+            "golzuna": "false",
+        }
 
     def _read_levels(self) -> dict[str, dict]:
         scenarios = {

--- a/open_dread_rando/templates/custom_core_x.lua
+++ b/open_dread_rando/templates/custom_core_x.lua
@@ -7,7 +7,9 @@ function CoreX_SuperGoliath.LaunchDamageSound(A0_2)
 end
 
 function CoreX_SuperGoliath.OnBigXAbsorbed(A0_2)
-  GUI.ShowMessage("#GUI_ITEM_ACQUIRED_LINE_BOMB", true, 'TEMPLATE("golzuna").OnPickedUp', false)
+  if TEMPLATE("golzuna") then
+    GUI.ShowMessage("#GUI_ITEM_ACQUIRED_LINE_BOMB", true, 'TEMPLATE("golzuna").OnPickedUp', false)
+  end
   local actor = Game.GetActor("doorpowerclosed_003")
   if actor ~= nil then
     actor.LIFE:UnLockDoor()

--- a/open_dread_rando/templates/custom_core_x_superquetzoa.lua
+++ b/open_dread_rando/templates/custom_core_x_superquetzoa.lua
@@ -8,7 +8,9 @@ end
 
 function CoreX_SuperQuetzoa.OnBigXAbsorbed(_ARG_0_)
   Game.PushSetup("PostSuperQuetzoaDead", true, false)
-  GUI.ShowMessage("#GUI_ITEM_ACQUIRED_MULTI_LOCK", true, 'TEMPLATE("escue").OnPickedUp', false)
+  if TEMPLATE("escue") then
+    GUI.ShowMessage("#GUI_ITEM_ACQUIRED_MULTI_LOCK", true, 'TEMPLATE("escue").OnPickedUp', false)
+  end
   local door = Game.GetActor("doorpowerpower_014")
   if  door ~= nil then
     door.LIFE:UnLockDoor()


### PR DESCRIPTION
Fixes #82.

Results in things like this:

```lua
function CoreX_SuperGoliath.OnBigXAbsorbed(A0_2)
  if RandomizerProgressiveITEM_WEAPON_MISSILE_MAX_2 then
    GUI.ShowMessage("#GUI_ITEM_ACQUIRED_LINE_BOMB", true, 'RandomizerProgressiveITEM_WEAPON_MISSILE_MAX_2.OnPickedUp', false)
  end
  local actor = Game.GetActor("doorpowerclosed_003")
  ...
end
```
```lua
function CoreX_SuperQuetzoa.OnBigXAbsorbed(_ARG_0_)
  Game.PushSetup("PostSuperQuetzoaDead", true, false)
  if false then
    GUI.ShowMessage("#GUI_ITEM_ACQUIRED_MULTI_LOCK", true, 'false.OnPickedUp', false)
  end
  local door = Game.GetActor("doorpowerpower_014")
  ...
end
```