### PR TITLE
Fix linked teleportal crash

### DIFF
--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -176,9 +176,42 @@ function Scenario.SetTeleportalUsed(actor)
     Scenario.ResetGlobalTeleport(actor)
 end
 
+local scenarios_with_teleport = {
+    s010_cave = "StartPoint0",
+    s020_magma = "savestation_000",
+    s030_baselab = "savestation_000",
+    s040_aqua = "savestation_000",
+    s050_forest = "savestation_000",
+    s070_basesanc = "savestation_000"
+}
+
+function Scenario.VisitAllTeleportScenarios()
+    if CurrentScenarioID == "s090_skybase" then
+        Blackboard.SetProp("GAME_PROGRESS", "RandoVisitScenarios", "b", true)
+    end
+
+    if not Blackboard.GetProp("GAME_PROGRESS", "RandoVisitScenarios") then return end
+
+    for scenario, spawn in pairs(scenarios_with_teleport) do
+        if not Blackboard.GetProp("GAME_PROGRESS", "RandoVisited"..scenario) then
+            Game.LoadScenario("c10_samus", scenario, spawn, "", 1)
+            return true
+        end
+    end
+
+    Blackboard.SetProp("GAME_PROGRESS", "RandoVisitScenarios", "b", false)
+    if CurrentScenarioID == "s090_skybase" then return false end
+    Game.LoadScenario("c10_samus", "s090_skybase", "elevator_shipyard_000_platform", "", 1)
+    return true
+end
+
 local original_onload = Scenario.OnLoadScenarioFinished
 function Scenario.OnLoadScenarioFinished()
     original_onload()
+
+    Blackboard.SetProp("GAME_PROGRESS", "RandoVisited" .. CurrentScenarioID, "b", true)
+
+    if Scenario.VisitAllTeleportScenarios() then return end
 
     local teleportal_id = Blackboard.GetProp("GAME_PROGRESS", "RandoUnlockTeleportal")
     if teleportal_id == nil then return end

--- a/open_dread_rando/files/levels/s010_cave.lc.lua
+++ b/open_dread_rando/files/levels/s010_cave.lc.lua
@@ -2108,6 +2108,8 @@ function s010_cave.OnUsableCancelUse(_ARG_0_)
   elseif _ARG_0_.sName == "PRP_CV_MapStation001" then
     s010_cave.OnTutoMapRoomBegins(true)
   end
+
+  Scenario.ResetGlobalTeleport(actor)
 end
 
 function s010_cave.OnUsablePrepareUse(_ARG_0_)
@@ -2116,12 +2118,16 @@ function s010_cave.OnUsablePrepareUse(_ARG_0_)
   elseif _ARG_0_.sName == "PRP_CV_MapStation001" then
     s010_cave.OnTutoMapRoomBegins(false)
   end
+
+  Scenario.DisableGlobalTeleport(_ARG_0_)
 end
 
 function s010_cave.OnUsableUse(_ARG_0_)
   if _ARG_0_.sName == "LE_Elevator_FromMagma" and not CAVES_TUTO_MAP_ROOM_DONE then
     Scenario.WriteToBlackboard(Scenario.LUAPropIDs.CAVES_TUTO_MAP_ROOM_DONE, "b", true)
   end
+
+  Scenario.SetTeleportalUsed(_ARG_0_)
 end
 
 

--- a/open_dread_rando/files/levels/s020_magma.lc.lua
+++ b/open_dread_rando/files/levels/s020_magma.lc.lua
@@ -755,6 +755,18 @@ function s020_magma.OnUsableFinishInteract(_ARG_0_)
   end
 end
 
+function s020_magma.OnUsablePrepareUse(actor)
+  Scenario.DisableGlobalTeleport(actor)
+end
+
+function s020_magma.OnUsableCancelUse(actor)
+  Scenario.ResetGlobalTeleport(actor)
+end
+
+function s020_magma.OnUsableUse(actor)
+  Scenario.SetTeleportalUsed(actor)
+end
+
 
 
 

--- a/open_dread_rando/files/levels/s030_baselab.lc.lua
+++ b/open_dread_rando/files/levels/s030_baselab.lc.lua
@@ -657,6 +657,19 @@ function s030_baselab.OnUsableFinishInteract(_ARG_0_)
   end
 end
 
+function s030_baselab.OnUsablePrepareUse(actor)
+  Scenario.DisableGlobalTeleport(actor)
+end
+
+function s030_baselab.OnUsableCancelUse(actor)
+  Scenario.ResetGlobalTeleport(actor)
+end
+
+function s030_baselab.OnUsableUse(actor)
+  Scenario.SetTeleportalUsed(actor)
+end
+
+
 
 
 function s030_baselab.SubAreaChangeRequest(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_)

--- a/open_dread_rando/files/levels/s040_aqua.lc.lua
+++ b/open_dread_rando/files/levels/s040_aqua.lc.lua
@@ -234,6 +234,19 @@ function s040_aqua.OnUsableFinishInteract(_ARG_0_)
   end
 end
 
+function s040_aqua.OnUsablePrepareUse(actor)
+  Scenario.DisableGlobalTeleport(actor)
+end
+
+function s040_aqua.OnUsableCancelUse(actor)
+  Scenario.ResetGlobalTeleport(actor)
+end
+
+function s040_aqua.OnUsableUse(actor)
+  Scenario.SetTeleportalUsed(actor)
+end
+
+
 
 
 

--- a/open_dread_rando/files/levels/s050_forest.lc.lua
+++ b/open_dread_rando/files/levels/s050_forest.lc.lua
@@ -265,6 +265,19 @@ function s050_forest.OnUsableFinishInteract(_ARG_0_)
   end
 end
 
+function s050_forest.OnUsablePrepareUse(actor)
+  Scenario.DisableGlobalTeleport(actor)
+end
+
+function s050_forest.OnUsableCancelUse(actor)
+  Scenario.ResetGlobalTeleport(actor)
+end
+
+function s050_forest.OnUsableUse(actor)
+  Scenario.SetTeleportalUsed(actor)
+end
+
+
 
 
 

--- a/open_dread_rando/files/levels/s060_quarantine.lc.lua
+++ b/open_dread_rando/files/levels/s060_quarantine.lc.lua
@@ -354,3 +354,15 @@ end
 function s060_quarantine.OnExit_ChangeCamera_004_B()
   Game.SetCollisionCameraLocked("collision_camera_004_B", false)
 end
+
+function s060_quarantine.OnUsablePrepareUse(actor)
+  Scenario.DisableGlobalTeleport(actor)
+end
+
+function s060_quarantine.OnUsableCancelUse(actor)
+  Scenario.ResetGlobalTeleport(actor)
+end
+
+function s060_quarantine.OnUsableUse(actor)
+  Scenario.SetTeleportalUsed(actor)
+end

--- a/open_dread_rando/files/levels/s070_basesanc.lc.lua
+++ b/open_dread_rando/files/levels/s070_basesanc.lc.lua
@@ -901,6 +901,18 @@ function s070_basesanc.OnUsableFinishInteract(_ARG_0_)
   end
 end
 
+function s070_basesanc.OnUsablePrepareUse(actor)
+  Scenario.DisableGlobalTeleport(actor)
+end
+
+function s070_basesanc.OnUsableCancelUse(actor)
+  Scenario.ResetGlobalTeleport(actor)
+end
+
+function s070_basesanc.OnUsableUse(actor)
+  Scenario.SetTeleportalUsed(actor)
+end
+
 
 
 

--- a/open_dread_rando/files/levels/s080_shipyard.lc.lua
+++ b/open_dread_rando/files/levels/s080_shipyard.lc.lua
@@ -435,6 +435,18 @@ function s080_shipyard.OnUsableFinishInteract(_ARG_0_)
   end
 end
 
+function s080_shipyard.OnUsablePrepareUse(actor)
+  Scenario.DisableGlobalTeleport(actor)
+end
+
+function s080_shipyard.OnUsableCancelUse(actor)
+  Scenario.ResetGlobalTeleport(actor)
+end
+
+function s080_shipyard.OnUsableUse(actor)
+  Scenario.SetTeleportalUsed(actor)
+end
+
 
 
 

--- a/open_dread_rando/files/levels/s090_skybase.lc.lua
+++ b/open_dread_rando/files/levels/s090_skybase.lc.lua
@@ -235,3 +235,15 @@ function s090_skybase.cutsceneplayer_108_end()
     Game.PlayCutsceneOnScenarioLoaded("cutsceneplayer_108", true, true, true, false, false, "", "", 0, 0, 0)
   end
 end
+
+function s090_skybase.OnUsablePrepareUse(actor)
+  Scenario.DisableGlobalTeleport(actor)
+end
+
+function s090_skybase.OnUsableCancelUse(actor)
+  Scenario.ResetGlobalTeleport(actor)
+end
+
+function s090_skybase.OnUsableUse(actor)
+  Scenario.SetTeleportalUsed(actor)
+end


### PR DESCRIPTION
 - Forces normal behavior when using a teleportal for the first time
 - Ensures all areas with teleportals are visited when linking teleportals for the first time by loading each unvisited one before entering itorash (fixes #101, closes #100)