### PR TITLE
Remove cutscenes causing Black screen issue

### DIFF
--- a/open_dread_rando/files/levels/s010_cave.lc.lua
+++ b/open_dread_rando/files/levels/s010_cave.lc.lua
@@ -1183,21 +1183,21 @@ function s010_cave.OnSubAreaChange(old_subarea, old_actorgroup, new_subarea, new
     end
   elseif old_subarea == "collision_camera_003" and new_subarea == "collision_camera_018" then
     
-    local oActor = Game.GetActor("cutsceneplayer_49-1")
-    if oActor ~= nil then
-      oActor.CUTSCENE:TryLaunchCutscene()
-    end
+  --  local oActor = Game.GetActor("cutsceneplayer_49-1")
+  --  if oActor ~= nil then
+  --    oActor.CUTSCENE:TryLaunchCutscene()
+  --  end
   elseif old_subarea == "collision_camera_018" and new_subarea == "collision_camera_005" then
     
-    local oActor1 = Game.GetActor("cutsceneplayer_49-1")
-    if oActor1 ~= nil then
-      if oActor1.CUTSCENE:HasCutsceneBeenPlayed() == true then
-        local oActor2 = Game.GetActor("cutsceneplayer_49-2")
-        if oActor2 ~= nil then
-          oActor2.CUTSCENE:TryLaunchCutscene()
-        end
-      end
-    end
+  --  local oActor1 = Game.GetActor("cutsceneplayer_49-1")
+  --  if oActor1 ~= nil then
+  --    if oActor1.CUTSCENE:HasCutsceneBeenPlayed() == true then
+  --      local oActor2 = Game.GetActor("cutsceneplayer_49-2")
+  --      if oActor2 ~= nil then
+  --        oActor2.CUTSCENE:TryLaunchCutscene()
+  --      end
+  --    end
+  --  end
     
     if not CAVES_CENTRAL_UNIT_WAKE_UP_CUTSCENE_LAUNCHED then
       Scenario.WriteToBlackboard(Scenario.LUAPropIDs.CAVES_CENTRAL_UNIT_WAKE_UP_CUTSCENE_LAUNCHED, "b", true)


### PR DESCRIPTION
There's an issue where triggering the 2 cutscenes in the lower entrance to the white EMMI zone (the CU wake up cutscenes) will cause a black screen (hear audio, but no GUI/camera) if skipped I believe, or maybe when the water is not drained or you skip that part?  I don't know.  Either way, it seems like the OnCutSceneEnd never gets called and that callback contains a simple FadeIn call, and thus, without that... you just get a black screen.
Regardless of the cause or the reasoning, with the Emmi Chase sequence removed, I believe these two cutscenes are now also safe to be removed as they do not trigger any game flags that make any sort of difference.