### PR TITLE
Feature: Added a tilegroup patcher API

### DIFF
--- a/open_dread_rando/dread_patcher.py
+++ b/open_dread_rando/dread_patcher.py
@@ -19,6 +19,7 @@ from open_dread_rando.patcher_editor import PatcherEditor
 from open_dread_rando.pickup import pickup_object_for
 from open_dread_rando.static_fixes import apply_static_fixes
 from open_dread_rando.text_patches import apply_text_patches, patch_credits, patch_hints, patch_text
+from open_dread_rando.tilegroup_patcher import patch_tilegroup
 from open_dread_rando.validator_with_default import DefaultValidatingDraft7Validator
 
 T = typing.TypeVar("T")
@@ -160,6 +161,9 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
 
     for door in configuration["door_patches"]:
         patch_door(editor, door)
+    
+    for tile_group in configuration["tile_group_patches"]:
+        patch_tilegroup(editor, tile_group)
 
     # Text patches
     if "text_patches" in configuration:

--- a/open_dread_rando/files/schema.json
+++ b/open_dread_rando/files/schema.json
@@ -410,6 +410,38 @@
             },
             "default": []
         },
+        "tile_group_patches": {
+            "type": "array",
+            "description": "Changes breakable tile group types",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "actor": {
+                        "$ref": "#/$defs/actor_reference_with_layer"
+                    },
+                    "tiletype": {
+                        "type": "string",
+                        "enum": [
+                            "POWERBEAM",
+                            "BOMB",
+                            "MISSILE",
+                            "SUPERMISSILE",
+                            "POWERBOMB",
+                            "SCREWATTACK",
+                            "WEIGHT",
+                            "BABYHATCHLING",
+                            "SPEEDBOOST"
+                        ]
+                    }
+                },
+                "required": [
+                    "actor",
+                    "tiletype"
+                ],
+                "additionalProperties": false
+            },
+            "default": []
+        },
         "spoiler_log": {
             "type": "object",
             "additionalProperties": {

--- a/open_dread_rando/tilegroup_patcher.py
+++ b/open_dread_rando/tilegroup_patcher.py
@@ -1,0 +1,20 @@
+from open_dread_rando.patcher_editor import PatcherEditor
+
+def is_tilegroup(actor):
+    return "TILEGROUP" in actor.pComponents and "CBreakableTileGroupComponent" == actor.pComponents.TILEGROUP["@type"]
+
+def patch_tilegroup(editor: PatcherEditor, group: dict):
+    """
+    Patches a tilegroup from its original tile type into a new tile type
+    
+    :param editor: the PatcherEditor
+    :param group: a dictionary containing the actor reference stored in 'actor' key and a tile type stored in 'tiletype' key
+    """
+    actor = editor.resolve_actor_reference(group["actor"])
+
+    if not is_tilegroup(actor):
+        raise ValueError(f"Actor at {group['actor']} is not a breakable tile group.")
+    
+    gridTiles = actor.pComponents.TILEGROUP.aGridTiles
+    for tile in gridTiles:
+        tile.eTileType = group["tiletype"]

--- a/open_dread_rando/tilegroup_patcher.py
+++ b/open_dread_rando/tilegroup_patcher.py
@@ -1,7 +1,7 @@
 from open_dread_rando.patcher_editor import PatcherEditor
 
 def is_tilegroup(actor):
-    return "TILEGROUP" in actor.pComponents and "CBreakableTileGroupComponent" == actor.pComponents.TILEGROUP["@type"]
+    return "TILEGROUP" in actor.pComponents and actor.pComponents.TILEGROUP["@type"] == "CBreakableTileGroupComponent"
 
 def patch_tilegroup(editor: PatcherEditor, group: dict):
     """


### PR DESCRIPTION
- breakable tile groups can be patched into different breakable blocks
- field "tile_group_patches" added to configuration, which contains an array of tile_group dicts
- tilegroup_patcher.py patches a tilegroup using an actor reference in the "actor" key and the new tile type in the "tiletype" key