### PR TITLE
Warn when entering Golzuna arena without X freed

### DIFF
--- a/open_dread_rando/files/levels/s050_forest.lc.lua
+++ b/open_dread_rando/files/levels/s050_forest.lc.lua
@@ -324,10 +324,6 @@ function s050_forest.OnSubAreaChange(old_subarea, old_actorgroup, new_subarea, n
       end
     end
   end
-  
-  if old_subarea == "collision_camera_036" and new_subarea == "collision_camera_026" and FOREST_POSTXRELEASE_APPLIED == false then
-    GUI.ShowMessage("You have entered the Golzuna boss arena without releasing the X. Since the X doesn't spawn this is a softlock. Restart from checkpoint to continue.", true, "")
-  end
 
   Scenario.UpdateProgressiveItemModels()
 end
@@ -857,6 +853,11 @@ end
 
 
 function s050_forest.LockDoorSuperGoliathArena(_ARG_0_, _ARG_1_)
+  -- provide warning when player falls into arena without finishing Elun
+  if Blackboard.GetProp("GAME_PROGRESS", "QUARENTINE_OPENED") == false then
+    GUI.ShowMessage("You have entered the Golzuna boss arena without releasing the X. Since the X doesn't spawn this is a softlock. Restart from checkpoint to continue.", true, "")
+  end
+
   local oActor = Game.GetActor("doorpowerclosed_003")
   if oActor ~= nil then
     oActor.LIFE:LockDoor()

--- a/open_dread_rando/files/levels/s050_forest.lc.lua
+++ b/open_dread_rando/files/levels/s050_forest.lc.lua
@@ -324,6 +324,10 @@ function s050_forest.OnSubAreaChange(old_subarea, old_actorgroup, new_subarea, n
       end
     end
   end
+  
+  if old_subarea == "collision_camera_036" and new_subarea == "collision_camera_026" and FOREST_POSTXRELEASE_APPLIED == false then
+    GUI.ShowMessage("You have entered the Golzuna boss arena without releasing the X. Since the X doesn't spawn this is a softlock. Restart from checkpoint to continue.", true, "")
+  end
 
   Scenario.UpdateProgressiveItemModels()
 end


### PR DESCRIPTION
- Added if branch to s050_forest.OnSubAreaChange() when dropping into Golzuna room without X released
- Message tells the player that X don't spawn from the enemy and instructs them to reload from checkpoint (#157)