### PR TITLE
Feature/unlock emmi doors immediately

### DIFF
--- a/open_dread_rando/files/levels/s020_magma.lc.lua
+++ b/open_dread_rando/files/levels/s020_magma.lc.lua
@@ -209,7 +209,7 @@ end
 
 function s020_magma.OnCheckpoint_MorphBall()
 
-  s020_magma.OnLockEmmyDoors()
+  s020_magma.OnUnlockEmmyDoors()
 end
 
 

--- a/open_dread_rando/files/levels/s020_magma.lc.lua
+++ b/open_dread_rando/files/levels/s020_magma.lc.lua
@@ -166,6 +166,7 @@ function s020_magma.OnEmmyAbilityObtainedFadeOutCompleted()
   local oActor = Game.GetActor("centralunitmagmacontroller")
   if oActor ~= nil then
     oActor.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
+    oActor.CENTRALUNIT:UnlockDoors()
   end
 end
 

--- a/open_dread_rando/files/levels/s030_baselab.lc.lua
+++ b/open_dread_rando/files/levels/s030_baselab.lc.lua
@@ -266,7 +266,7 @@ end
 
 
 function s030_baselab.OnCheckpoint_SpeedBooster()
-  s030_baselab.OnLockEmmyDoors()
+  s030_baselab.OnUnlockEmmyDoors()
 end
 
 

--- a/open_dread_rando/files/levels/s030_baselab.lc.lua
+++ b/open_dread_rando/files/levels/s030_baselab.lc.lua
@@ -211,6 +211,7 @@ function s030_baselab.OnEmmyAbilityObtainedFadeOutCompleted()
   local oActor = Game.GetActor("centralunitmagmacontroller") 
   if oActor ~= nil then
     oActor.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
+    oActor.CENTRALUNIT:UnlockDoors()
   end
 end
 

--- a/open_dread_rando/files/levels/s050_forest.lc.lua
+++ b/open_dread_rando/files/levels/s050_forest.lc.lua
@@ -392,6 +392,7 @@ function s050_forest.OnEmmyAbilityObtainedFadeOutCompleted()
   local oActor = Game.GetActor("centralunitmagmacontroller")
   if oActor ~= nil then
     oActor.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
+    oActor.CENTRALUNIT:UnlockDoors()
   end
 end
 

--- a/open_dread_rando/files/levels/s070_basesanc.lc.lua
+++ b/open_dread_rando/files/levels/s070_basesanc.lc.lua
@@ -408,6 +408,7 @@ function s070_basesanc.OnEmmyAbilityObtainedFadeOutCompleted()
   local L0_2 = Game.GetActor("centralunitmagmacontroller")
   if L0_2 ~= nil then
     L0_2.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
+    oActor.CENTRALUNIT:UnlockDoors()
   end
 end
 

--- a/open_dread_rando/files/levels/s070_basesanc.lc.lua
+++ b/open_dread_rando/files/levels/s070_basesanc.lc.lua
@@ -408,7 +408,7 @@ function s070_basesanc.OnEmmyAbilityObtainedFadeOutCompleted()
   local L0_2 = Game.GetActor("centralunitmagmacontroller")
   if L0_2 ~= nil then
     L0_2.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
-    oActor.CENTRALUNIT:UnlockDoors()
+    L0_2.CENTRALUNIT:UnlockDoors()
   end
 end
 


### PR DESCRIPTION
Just added another call to CENTRALUNIT in `OnEmmyAbilityObtainedFadeOutComplete()` in the applicable scenarios, so doors are unlocked after the EMMI death cutscene. 