### PR TITLE
Grant Item from Corpius before checkpoint

### DIFF
--- a/open_dread_rando/files/levels/s010_cave.lc.lua
+++ b/open_dread_rando/files/levels/s010_cave.lc.lua
@@ -2289,3 +2289,6 @@ function s010_cave.cutsceneplayer_57_delayed()
     oActor.bEnabled = false
   end
 end
+
+function s010_cave.OnCorpiusDeath_CUSTOM()
+end

--- a/open_dread_rando/files/levels/s020_magma.lc.lua
+++ b/open_dread_rando/files/levels/s020_magma.lc.lua
@@ -865,7 +865,7 @@ function s020_magma.OnCutscene78Started()
   Game.SetSFXVolume(L0_2, 0)
 end
 
-function s020_magma.OnCutscene81Ended()
+function s020_magma.OnExperimentDeath_CUSTOM()
     
     
   s020_magma.Cooldown_Deactivation()

--- a/open_dread_rando/static_fixes.py
+++ b/open_dread_rando/static_fixes.py
@@ -169,7 +169,7 @@ def apply_drogyga_fixes(editor: PatcherEditor):
         "scenario": "s040_aqua",
         "layer": "cutscenes",
         "actor": "cutsceneplayer_65"
-    }, "CurrentScenario.OnHydrogigaDead_CUSTOM")
+    }, "CurrentScenario.OnHydrogigaDead_CUSTOM", -1)
 
     # remove the trigger that deletes drogyga until after beating drogyga
     aqua = editor.get_scenario("s040_aqua")

--- a/open_dread_rando/static_fixes.py
+++ b/open_dread_rando/static_fixes.py
@@ -149,6 +149,13 @@ def _apply_boss_cutscene_fixes(editor: PatcherEditor, cutscene_ref: dict, callba
             callbacks_after_cutscene[i:i] = [callback_action]
 
 
+def apply_corpius_fixes(editor: PatcherEditor):
+    _apply_boss_cutscene_fixes(editor, {
+        "scenario": "s010_cave",
+        "layer": "Cutscenes",
+        "actor": "cutsceneplayer_57"
+    }, "CurrentScenario.OnCorpiusDeath_CUSTOM", 0)
+
 def apply_kraid_fixes(editor: PatcherEditor):
     _apply_boss_cutscene_fixes(editor, {
         "scenario": "s020_magma",
@@ -349,6 +356,7 @@ def apply_static_fixes(editor: PatcherEditor):
     activate_emmi_zones(editor)
     apply_one_sided_door_fixes(editor)
     apply_kraid_fixes(editor)
+    apply_corpius_fixes(editor)
     fix_backdoor_white_cu(editor)
     patch_corpius_checkpoints(editor)
     apply_experiment_fixes(editor)

--- a/open_dread_rando/static_fixes.py
+++ b/open_dread_rando/static_fixes.py
@@ -299,7 +299,7 @@ def apply_experiment_fixes(editor: PatcherEditor):
         "scenario": "s020_magma",
         "layer": "cutscenes",
         "actor": "cutsceneplayer_81"
-    }, "")
+    }, "CurrentScenario.OnExperimentDeath_CUSTOM", 0)
 
     new_triggers = {
         "TriggerEnableCooldown": (5050.000, -5346.150, 0.000),


### PR DESCRIPTION
As posted in the discord Corpius has the same bug as Kraid had. Probably more bosses are effected. At least also Drogyga.

It's likely always the same: The Lua Script for granting the item is called after the checkpoint is saved but as part of the cutscene callback, so it will be lost if you reload the checkpoint.

I suggest to do it always the same way: Check in Dread Editor at which position the checkpoint is saved and grant the item right before it with a OnXXXDeath_Custom script.
Will this be accepted? Then I will test and patch all bosses. Probably all with cutscenes like Corpius, Kraid, Drogyga, Z-57.

As you can see in the screenshot, OnCutscene0057Finished, which is what we hook currently for granting the item for corpius, is called after the checkpoint 
![image](https://user-images.githubusercontent.com/117127188/202873206-2458e61b-2706-4da6-ab9b-d0508bd68b18.png)

There is only one thing, I'm quite unsure about: Randovania needs a patch too. In Artaria.json I replaced the callback_function with:
```
                    "extra": {
                        "pickup_type": "corpius",
                        "actor_def": "actors/characters/scorpius/charclasses/scorpius.bmsad",
                        "string_key": "GUI_ITEM_ACQUIRED_OPTICAL_CAMO",
                        "callback_function": "OnCorpiusDeath_CUSTOM",
                        "boss_hint_name": "Corpius"
                    },
```
It is working this way. But should I change the pickup_type to be `cutscene`? Then the patch for removing the phantom cloak from corpius needs to be done differently. `CorpiusPickup` in `pickup.py` is only executed when the `pickup_type` is `corpius` without that type present it would probably grant always an additional phantom cloak. https://github.com/randovania/open-dread-rando/blob/8a3ed5a58b6bda8b756f45698fde1958f7f9a6dd/open_dread_rando/pickup.py#L306-L312

On a side note: Quite funny that the layer is called `cutscenes` but `Cutscenes` with capital C for the s010_cave