### PR TITLE
fix pickup of main pb for bosses

### DIFF
--- a/open_dread_rando/files/randomizer_powerup.lua
+++ b/open_dread_rando/files/randomizer_powerup.lua
@@ -219,6 +219,9 @@ RandomizerPowerBomb = {}
 setmetatable(RandomizerPowerBomb, {__index = RandomizerPowerup})
 function RandomizerPowerBomb.OnPickedUp(actor, progression)
     progression = progression or {{item_id = "ITEM_WEAPON_POWER_BOMB_MAX", quantity = 0}}
+    if progression[1].item_id == "ITEM_WEAPON_POWER_BOMB" then
+        progression[1].item_id = "ITEM_WEAPON_POWER_BOMB_MAX"
+    end
     if actor ~= nil then
         -- actor pickups grant the quantity directly; bosses do not
         progression[1].quantity = 0


### PR DESCRIPTION
Smallest possible patch for the bug that bosses do not grant ammo for pbs.

Current logic:
RDV creates something like
```
        {
            "pickup_type": "actor",
            "caption": "Main Power Bomb acquired.",
            "resources": [
                {
                    "item_id": "ITEM_WEAPON_POWER_BOMB",
                    "quantity": 4
                }
            ],
            "pickup_actor": {
                "scenario": "s040_aqua",
                "layer": "default",
                "actor": "item_missiletank_004"
            },
            "model": [
                "powerup_powerbomb"
            ],
            "map_icon": {
                "icon_id": "powerup_powerbomb"
            }
        }
```

where the quantity is set to how many pb tanks you get from main pb. This means the weapon itself is actually mixed with the amount of pb tanks.

For actors the pickup is changed to ITEM_WEAPON_POWER_BOMB_MAX and granting pb tanks instead of main pb.

https://github.com/randovania/open-dread-rando/blob/5e0f174dc8e7b7304c7146a8caa48e10630df8d4/open_dread_rando/pickup.py#L111-L117

The lua script `RandomizerPowerBomb.OnPickedUp` just checks if `ITEM_WEAPON_POWER_BOMB_MAX` was granted and then sets the item amount of main pb to be 1.
https://github.com/randovania/open-dread-rando/blob/5e0f174dc8e7b7304c7146a8caa48e10630df8d4/open_dread_rando/files/randomizer_powerup.lua#L227-L229

-----

If we don't have an actor the replacement described for / in `pickup.py` does not take place and `RandomizerPowerBomb.OnPickedUp` is called like:
```
function RandomizerProgressiveITEM_WEAPON_POWER_BOMB_4.OnPickedUp(actor)
    Game.LogWarn(0, "picked up RandomizerProgressiveITEM_WEAPON_POWER_BOMB_4")
    local progression = {
{
item_id = "ITEM_WEAPON_POWER_BOMB",
quantity = 4,
},
}
    RandomizerPowerBomb.OnPickedUp(actor, progression)
end
```

The patch simply modifies `ITEM_WEAPON_POWER_BOMB` to  `ITEM_WEAPON_POWER_BOMB_MAX` in `RandomizerPowerBomb.OnPickedUp`. So, it will grant pb tanks and because pb tanks are granted, it sets the `ITEM_WEAPON_POWER_BOMB` amount to 1 at the end (like described above).

---

Alternative: Maybe resources should be something like:
```
            "resources": [
                {
                    "item_id": "ITEM_WEAPON_POWER_BOMB_MAX",
                    "quantity": 4
                },
                {
                    "item_id": "ITEM_WEAPON_POWER_BOMB",
                    "quantity": 1
                }
            ],
```
but multiple resourcs are always considered to be a progression and therefore needs a few more changes in the code. If this is preffered, I could do that too.

Therefore I will open this as a draft at first. 