### PR TITLE
Rename of functions in starter_preset_patcher.json

### DIFF
--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -3069,7 +3069,7 @@
             ],
             "pickup_lua_callback": {
                 "scenario": "s010_cave",
-                "function": "OnCutscene0057Finished",
+                "function": "OnCorpiusDeath_CUSTOM",
                 "args": 0
             },
             "pickup_actordef": "actors/characters/scorpius/charclasses/scorpius.bmsad",
@@ -3118,7 +3118,7 @@
             ],
             "pickup_lua_callback": {
                 "scenario": "s020_magma",
-                "function": "OnCutscene81Ended",
+                "function": "OnExperimentDeath_CUSTOM",
                 "args": 0
             }
         },


### PR DESCRIPTION
In one of my previous PR, I have been advised to add to `test/test_files/starter_preset_patcher.json`
I assume the renamed functions of my boss pickup fix should be added to this file, too.