### PR TITLE
Add Death Counter option

### DIFF
--- a/open_dread_rando/dread_patcher.py
+++ b/open_dread_rando/dread_patcher.py
@@ -32,7 +32,7 @@ def _read_schema():
 
 
 def create_custom_init(editor: PatcherEditor, configuration: dict):
-    cosmetic_options: dict = configuration["cosmetic_patches"]["lua"].get("custom_init", {})
+    cosmetic_options: dict = configuration["cosmetic_patches"]["lua"]["custom_init"]
     inventory: dict[str, int] = configuration["starting_items"]
     starting_location: dict = configuration["starting_location"]
     starting_text: list[list[str]] = configuration.get("starting_text", [])
@@ -90,7 +90,7 @@ def create_custom_init(editor: PatcherEditor, configuration: dict):
         "linear_dps": configuration.get("linear_dps"),
         "configuration_identifier": lua_util.wrap_string(configuration_identifier),
         "required_artifacts": configuration["objective"]["required_artifacts"],
-        "enable_death_counter": cosmetic_options.get("enable_death_counter", False)
+        "enable_death_counter": cosmetic_options.get("enable_death_counter")
     }
 
     replacement.update(configuration.get("game_patches", {}))

--- a/open_dread_rando/dread_patcher.py
+++ b/open_dread_rando/dread_patcher.py
@@ -90,7 +90,7 @@ def create_custom_init(editor: PatcherEditor, configuration: dict):
         "linear_dps": configuration.get("linear_dps"),
         "configuration_identifier": lua_util.wrap_string(configuration_identifier),
         "required_artifacts": configuration["objective"]["required_artifacts"],
-        "enable_death_counter": cosmetic_options.get("enable_death_counter")
+        "enable_death_counter": cosmetic_options["enable_death_counter"]
     }
 
     replacement.update(configuration.get("game_patches", {}))

--- a/open_dread_rando/dread_patcher.py
+++ b/open_dread_rando/dread_patcher.py
@@ -32,6 +32,7 @@ def _read_schema():
 
 
 def create_custom_init(editor: PatcherEditor, configuration: dict):
+    cosmetic_options: dict = configuration["cosmetic_patches"]["lua"].get("custom_init", {})
     inventory: dict[str, int] = configuration["starting_items"]
     starting_location: dict = configuration["starting_location"]
     starting_text: list[list[str]] = configuration.get("starting_text", [])
@@ -88,7 +89,8 @@ def create_custom_init(editor: PatcherEditor, configuration: dict):
         "linear_damage_runs": configuration.get("linear_damage_runs"),
         "linear_dps": configuration.get("linear_dps"),
         "configuration_identifier": lua_util.wrap_string(configuration_identifier),
-        "required_artifacts": configuration["objective"]["required_artifacts"]
+        "required_artifacts": configuration["objective"]["required_artifacts"],
+        "enable_death_counter": cosmetic_options.get("enable_death_counter", False)
     }
 
     replacement.update(configuration.get("game_patches", {}))

--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -3,6 +3,7 @@ Game.ImportLibrary("system/scripts/scenario_original.lua")
 Game.DoFile("system/scripts/input_handling.lua")
 Game.DoFile("system/scripts/data_structures.lua")
 Game.DoFile("system/scripts/guilib.lua")
+Game.DoFile("system/scripts/death_counter.lua")
 
 Scenario.tRandoHintPropIDs = {
     CAVE_1 = Blackboard.RegisterLUAProp("HINT_CAVE_1", "bool"),
@@ -293,7 +294,7 @@ end
 function Scenario.CheckWarpToStart(actor)
     if not Scenario.IsSaveStation(actor) then return end
     if not Init.bWarpToStart then return end
-    
+
     Input.LogInputs()
     if Input.CheckInputs("ZL", "ZR") then
         Scenario.TeleportToStartPoint(Init.sStartingScenario, Init.sStartingActor)
@@ -337,21 +338,21 @@ function Scenario.TeleportToLocalStartPoint(startpoint)
     end
     Game.AddSF(fTeleportStartDelay, "Scenario.OnTeleportFadeOut", "s", startpoint)
 end
-  
-  
+
+
 function Scenario.OnTeleportFadeOut(startpoint)
     Game.FadeOut(fTeleportFadeOutTime)
     Game.AddSF(fTeleportFadeOutTime + fTeleportBlackScreenTime, "Scenario.OnStartPointTeleport", "s", startpoint)
 end
-  
-  
+
+
 function Scenario.OnStartPointTeleport(startpoint)
     Game.TeleportEntityToStartPoint(Game.GetPlayerName(), startpoint, fTeleportFadeInTime, true)
     Game.FadeIn(0.1, fTeleportFadeInTime)
     Game.AddSF(0, "Scenario.OnTeleportFinished", "")
 end
-  
-  
+
+
 function Scenario.OnTeleportFinished()
     Scenario.EnableInput()
     Game.ReinitPlayerFromBlackboard()
@@ -375,6 +376,8 @@ function Scenario.InitGui()
     })
     ui:Show()
     Scenario.RandoUI = ui
+
+    DeathCounter.Create()
 end
 
 Scenario.QueuedPopups = Scenario.QueuedPopups or Queue()

--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -377,7 +377,9 @@ function Scenario.InitGui()
     ui:Show()
     Scenario.RandoUI = ui
 
-    DeathCounter.Create()
+    if Init.bEnableDeathCounter then
+        DeathCounter.Create()
+    end
 end
 
 Scenario.QueuedPopups = Scenario.QueuedPopups or Queue()

--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -108,6 +108,10 @@ function Scenario.InitScenario(arg1, arg2, arg3, arg4)
         Game.AddSF(0.9, Init.SaveGameAtStartingLocation, "")
         Game.AddSF(0.8, Scenario.ShowText, "")
     end
+
+    if Init.bEnableDeathCounter then
+        DeathCounter.OnScenarioInitialized()
+    end
 end
 
 local fatal_messages_seen = 0
@@ -378,7 +382,7 @@ function Scenario.InitGui()
     Scenario.RandoUI = ui
 
     if Init.bEnableDeathCounter then
-        DeathCounter.Create()
+        DeathCounter.Init()
     end
 end
 

--- a/open_dread_rando/files/lua_libraries/death_counter.lua
+++ b/open_dread_rando/files/lua_libraries/death_counter.lua
@@ -1,8 +1,26 @@
-DeathCounter = DeathCounter or {}
+DeathCounter = DeathCounter or {
+	didPatchOnPlayerDead = false,
+	newPlayerDeathCount = nil,
+}
 
-function DeathCounter.Create()
+function DeathCounter.Init()
 	if DeathCounter.ui then
 		GUI.DestroyDisplayObject(DeathCounter.ui)
+	end
+
+	if not DeathCounter.didPatchOnPlayerDead then
+		-- Patch the "DamagePlants.OnPlayerDeath" function, which is unused in Dread, to detect when the player has died
+		local original_OnPlayerDead = DamagePlants.OnPlayerDead
+
+		DamagePlants.OnPlayerDead = function(...)
+			original_OnPlayerDead(...)
+
+			local deathCount = Blackboard.GetProp("GAME", "Rando_PlayerDeathCount") or 0
+
+			DeathCounter.newPlayerDeathCount = deathCount + 1
+		end
+
+		DeathCounter.didPatchOnPlayerDead = true
 	end
 
 	local hud = GUI.GetDisplayObject("IngameMenuRoot.iconshudcomposition")
@@ -44,8 +62,17 @@ function DeathCounter.Create()
 	DeathCounter.ui = container
 	DeathCounter.label = label
 	DeathCounter.Update()
+end
 
-	return container
+function DeathCounter.OnScenarioInitialized()
+	-- If we store the new death count on "OnPlayerDead", it will get reset back to 0 when the player continues, because
+	-- the Blackboard will be loaded from the last checkpoint. We have to store the new value into the Blackboard AFTER
+	-- the player loads back to the checkpoint.
+	if type(DeathCounter.newPlayerDeathCount) == "number" then
+		Game.LogWarn(0, ("Storing %d to Rando_PlayerDeathCount"):format(DeathCounter.newPlayerDeathCount))
+		Blackboard.SetProp("GAME", "Rando_PlayerDeathCount", "i", DeathCounter.newPlayerDeathCount)
+		DeathCounter.newPlayerDeathCount = nil
+	end
 end
 
 function DeathCounter.CreateBackgroundComposition(container)
@@ -89,7 +116,18 @@ function DeathCounter.Update()
 		return
 	end
 
-	local deathCount = Blackboard.GetProp("GAME", "ProgressStat_PlayerDeaths") or 0
+	-- Try to use official BB property if present (2.0.0+). The official stat is guaranteed to match the end screen,
+	-- so in case our custom property somehow gets out of sync, the HUD will still show the correct count on newer
+	-- game versions.
+	local deathCount = Blackboard.GetProp("GAME", "ProgressStat_PlayerDeaths")
+
+	Game.LogWarn(0, ("deathCount: %s = %s"):format(type(deathCount), tostring(deathCount)))
+
+	if type(deathCount) ~= "number" then
+		-- Official prop didn't exist (we're probably on 1.0.x), use our own stat
+		deathCount = Blackboard.GetProp("GAME", "Rando_PlayerDeathCount") or 0
+		Game.LogWarn(0, ("Got %s back from Rando_PlayerDeathCount"):format(tostring(deathCount)))
+	end
 
 	GUI.SetLabelText(label, "Deaths: " .. deathCount)
 end

--- a/open_dread_rando/files/lua_libraries/death_counter.lua
+++ b/open_dread_rando/files/lua_libraries/death_counter.lua
@@ -1,0 +1,76 @@
+DeathCounter = DeathCounter or {}
+
+function DeathCounter.Create()
+	if DeathCounter.ui then
+		GUI.DestroyDisplayObject(DeathCounter.ui)
+	end
+
+	local hud = GUI.GetDisplayObject("IngameMenuRoot.iconshudcomposition")
+	local container = GUI.CreateDisplayObject(hud, "DeathCounter", "CDisplayObjectContainer", {
+		X = "0.025",
+		Y = "0.1925",
+		ScaleX = "1.0",
+		ScaleY = "1.0",
+		Angle = "0.0",
+		SizeX = "0.2",
+		SizeY = "0.04",
+		Enabled = true,
+		Visible = true,
+	})
+
+	DeathCounter.CreateBackgroundComposition(container)
+
+	local label = GUI.CreateDisplayObject(container, "DeathCounter_Label", "CLabel", {
+		X = "0.005",
+		Y = "0.0",
+		ScaleX = "1.0",
+		ScaleY = "1.0",
+		Angle = "0.0",
+		SizeX = "0.2",
+		SizeY = "0.04",
+		Enabled = true,
+		Visible = true,
+		Text = "Deaths: 0",
+		Font = "digital_small",
+		TextAlignment = "Left",
+		TextVerticalAlignment = "Centered",
+		Autosize = false,
+		ColorR = "1.0",
+		ColorG = "1.0",
+		ColorB = "1.0",
+		ColorA = "1.0",
+	})
+
+	DeathCounter.ui = container
+	DeathCounter.label = label
+	DeathCounter.Update()
+
+	return container
+end
+
+function DeathCounter.CreateBackgroundComposition(container)
+	GUI.CreateDisplayObject(container, "Background", "CSprite", {
+		X = "0.0",
+		Y = "0.0",
+		SizeX = "0.1",
+		SizeY = "0.04",
+		Autosize = false,
+		SpriteSheetItem = "HUD_TILESET/BACKGROUND",
+		ColorR = "1.0",
+		ColorG = "1.0",
+		ColorB = "1.0",
+		ColorA = "1.0",
+	})
+end
+
+function DeathCounter.Update()
+	local label = DeathCounter.label
+
+	if not label then
+		return
+	end
+
+	local deathCount = Blackboard.GetProp("GAME", "ProgressStat_PlayerDeaths") or 0
+
+	GUI.SetLabelText(label, "Deaths: " .. deathCount)
+end

--- a/open_dread_rando/files/lua_libraries/death_counter.lua
+++ b/open_dread_rando/files/lua_libraries/death_counter.lua
@@ -8,7 +8,7 @@ function DeathCounter.Create()
 	local hud = GUI.GetDisplayObject("IngameMenuRoot.iconshudcomposition")
 	local container = GUI.CreateDisplayObject(hud, "DeathCounter", "CDisplayObjectContainer", {
 		X = "0.025",
-		Y = "0.1925",
+		Y = "0.1975",
 		ScaleX = "1.0",
 		ScaleY = "1.0",
 		Angle = "0.0",
@@ -21,7 +21,7 @@ function DeathCounter.Create()
 	DeathCounter.CreateBackgroundComposition(container)
 
 	local label = GUI.CreateDisplayObject(container, "DeathCounter_Label", "CLabel", {
-		X = "0.005",
+		X = "0.0075",
 		Y = "0.0",
 		ScaleX = "1.0",
 		ScaleY = "1.0",
@@ -56,9 +56,28 @@ function DeathCounter.CreateBackgroundComposition(container)
 		SizeY = "0.04",
 		Autosize = false,
 		SpriteSheetItem = "HUD_TILESET/BACKGROUND",
+		BlendMode = "AlphaBlend",
+		USelMode = "Scale",
+		VSelMode = "Scale",
 		ColorR = "1.0",
 		ColorG = "1.0",
 		ColorB = "1.0",
+		ColorA = "1.0",
+	})
+
+	GUI.CreateDisplayObject(container, "Frame_top", "CSprite", {
+		X = "0.0",
+		Y = "0.0",
+		SizeX = "0.05",
+		SizeY = "0.015",
+		Autosize = false,
+		SpriteSheetItem = "HUD_TILESET/FRAME_TOP",
+		BlendMode = "AlphaBlend",
+		USelMode = "Scale",
+		VSelMode = "Scale",
+		ColorR = "0.8773584961891174",
+		ColorG = "0.8773584961891174",
+		ColorB = "0.8773584961891174",
 		ColorA = "1.0",
 	})
 end

--- a/open_dread_rando/files/schema.json
+++ b/open_dread_rando/files/schema.json
@@ -304,7 +304,21 @@
                     "type": "object"
                 },
                 "lua": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "custom_init": {
+                            "type": "object",
+                            "properties": {
+                                "enable_death_counter": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "Enables an in-game death counter shown in the player's HUD"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "required": [

--- a/open_dread_rando/files/schema.json
+++ b/open_dread_rando/files/schema.json
@@ -302,10 +302,14 @@
             "properties": {
                 "config": {
                     "type": "object"
+                },
+                "lua": {
+                    "type": "object"
                 }
             },
             "required": [
-                "config"
+                "config",
+                "lua"
             ]
         },
         "enable_remote_lua": {

--- a/open_dread_rando/templates/custom_init.lua
+++ b/open_dread_rando/templates/custom_init.lua
@@ -44,6 +44,7 @@ Init.bDefaultXRelease = TEMPLATE("default_x_released")
 Init.bEnableExperimentBoss = TEMPLATE("enable_experiment_boss")
 Init.iNumRequiredArtifacts = TEMPLATE("required_artifacts")
 Init.bWarpToStart = TEMPLATE("warp_to_start")
+Init.bEnableDeathCounter = TEMPLATE("enable_death_counter")
 
 Game.LogWarn(0, "Inventory:")
 for k, v in pairs(Init.tNewGameInventory) do

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -3864,6 +3864,11 @@
                 "bShowEnemyDamage": false,
                 "bShowPlayerDamage": true
             }
+        },
+        "lua": {
+            "custom_init": {
+                "enable_death_counter": true
+            }
         }
     },
     "energy_per_tank": 100,


### PR DESCRIPTION
This adds a death counter to the player's HUD, togglable from the patcher.json input (will be a cosmetic option in Randovania). When enabled, an item will be added just below the player's HUD indicating the number of times they have died since starting the current game file.

![image](https://user-images.githubusercontent.com/816612/216481119-c19dd566-a190-442d-872a-a7db3097b030.png)
