### PR TITLE
Fix progressive item models when player is missing an earlier item

### DIFF
--- a/open_dread_rando/files/custom_scenario.lua
+++ b/open_dread_rando/files/custom_scenario.lua
@@ -208,13 +208,20 @@ function Scenario._UpdateProgressiveItemModels()
     for name, actordef in pairs(Game.GetEntities()) do
         local progressive_models = RandomizerPowerup.tProgressiveModels[actordef]
         if progressive_models ~= nil then
+            local alias = nil
+
             for _, model in ipairs(progressive_models) do
-                if RandomizerPowerup.HasItem(model.item) then
-                    local pickup = Game.GetActor(name)
-                    pickup.MODELUPDATER.sModelAlias = model.alias
-                    pickup.MODELUPDATER:ForceUpdate()
+                if not RandomizerPowerup.HasItem(model.item) then
                     break
                 end
+
+                alias = model.alias
+            end
+
+            if alias then
+                local pickup = Game.GetActor(name)
+                pickup.MODELUPDATER.sModelAlias = alias
+                pickup.MODELUPDATER:ForceUpdate()
             end
         end
     end

--- a/open_dread_rando/lua_editor.py
+++ b/open_dread_rando/lua_editor.py
@@ -93,7 +93,6 @@ class LuaEditor:
                 [(pickup["resources"][-1], pickup["model"][-1])],
             )
         ]
-        progressive_models.reverse()
 
         replacement = {
             "actordef_name": actordef_name,


### PR DESCRIPTION
I played a seed recently that had me start with Plasma Beam. The logic expects the first Progressive Beam to be "Wide Beam", and that is in fact what it grants when you pick it up in-game (which seems like you're picking up nothing, of course). The item, however, looked like Wave Beam before I picked it up. This should fix the model updater so that it will correctly show the _next_ item you will receive, even if you're only have a middle item. I tested with several different combinations of beams in my save file and it yielded the expected results (the item model always matched what it granted).