### PR TITLE
Change enable_remote_lua to false

### DIFF
--- a/open_dread_rando/files/schema.json
+++ b/open_dread_rando/files/schema.json
@@ -328,7 +328,7 @@
         },
         "enable_remote_lua": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "When true, the game will start a socket that receives lua code to run"
         },
         "constant_environment_damage": {


### PR DESCRIPTION
Just changed the default to false.
Ryujinx will not crash anymore on stop emulation or on exit.
Because Randovania does not set this at all, the default is taken for all seeds. Should be set later in randovania if multiworld happens.