### PR TITLE
Increase sensor door's door collider to cover normal doors

### DIFF
--- a/open_dread_rando/door_patcher.py
+++ b/open_dread_rando/door_patcher.py
@@ -163,7 +163,7 @@ class DoorPatcher:
         }
         self.SHIELD = editor.resolve_actor_reference(_EXAMPLE_SHIELD)
         self.rename_all_shields()
-        self.patch_doorpresence_colision()
+        self.patch_doorpresence_collision()
 
     def door_actor_to_type(self, door: Container, scenario: str) -> DoorType:
         """
@@ -398,10 +398,10 @@ class DoorPatcher:
         if shieldId is not None:
             insort(self.available_shield_ids[scenario], shieldId)
     
-    def patch_doorpresence_colision(self):
+    def patch_doorpresence_collision(self):
         # extends the door collider in doorpresence actor to 300x300 to maintain the size of normal doors
         # this looks a bit bad, but it'll do until we figure out how to edit navmeshes
         # (or whatever is storing the intended hitboxes for doors)
         doorpresence = self.editor.get_file("actors/props/doorpresence/collisions/doorpresence.bmscd", Bmscc)
         door_collider = doorpresence.raw.layers[0].entries[0]
-        door_collider.data.max = ListContainer([300.0,300.0])
+        door_collider.data.max = ListContainer([300.0,320.0])

--- a/open_dread_rando/door_patcher.py
+++ b/open_dread_rando/door_patcher.py
@@ -9,6 +9,8 @@ from construct import Container, ListContainer
 from open_dread_rando.common_data import ALL_SCENARIOS
 from open_dread_rando.patcher_editor import PatcherEditor
 
+from mercury_engine_data_structures.formats import Bmscc
+
 # copied from existing entity, so we don't have to make a whole shield
 _EXAMPLE_SHIELD = {"scenario": "s010_cave", "layer": "default", "actor": "Door003_missileShield"}
 
@@ -121,7 +123,7 @@ class DoorType(Enum):
     MISSILE = ("missile", ActorData.DOOR_POWER, True, ActorData.SHIELD_MISSILE)
     SUPER_MISSILE = ("super_missile", ActorData.DOOR_POWER, True, ActorData.SHIELD_SUPER_MISSILE)
     GRAPPLE = ("grapple_beam", ActorData.DOOR_GRAPPLE, False, None, True, True, ["actors/props/door"])
-    PRESENCE = ("phantom_cloak", ActorData.DOOR_PRESENCE, False, None, True, False, ["actors/props/door"])
+    PRESENCE = ("phantom_cloak", ActorData.DOOR_PRESENCE, False, None, True, True, ["actors/props/door", "actors/props/doorpresence"])
 
     def __init__(self, rdv_door_type: str, door_data: ActorData, need_shield: bool = False,
                  shield_data: ActorData = None, can_be_removed: bool = True, can_be_added: bool = True, additional_asset_folders: list[str] = None):
@@ -161,6 +163,7 @@ class DoorPatcher:
         }
         self.SHIELD = editor.resolve_actor_reference(_EXAMPLE_SHIELD)
         self.rename_all_shields()
+        self.patch_doorpresence_colision()
 
     def door_actor_to_type(self, door: Container, scenario: str) -> DoorType:
         """
@@ -394,3 +397,11 @@ class DoorPatcher:
         shieldId = int(sName.split("_")[1]) if "RandoShield" in sName else None
         if shieldId is not None:
             insort(self.available_shield_ids[scenario], shieldId)
+    
+    def patch_doorpresence_colision(self):
+        # extends the door collider in doorpresence actor to 300x300 to maintain the size of normal doors
+        # this looks a bit bad, but it'll do until we figure out how to edit navmeshes
+        # (or whatever is storing the intended hitboxes for doors)
+        doorpresence = self.editor.get_file("actors/props/doorpresence/collisions/doorpresence.bmscd", Bmscc)
+        door_collider = doorpresence.raw.layers[0].entries[0]
+        door_collider.data.max = ListContainer([300.0,300.0])


### PR DESCRIPTION
Sensor doors are not able to be randomized to since their "closed door" collider is smaller than a standard door's, and each door's vanilla collider seems to be baked into the navmesh/collision data. This increases the size of sensor door's `door` max collider distance from `(200,320)` to `(300,320)`, which covers the maximum collider size of the standard doors. 

Keeping this as a draft until the stable release is sent out next week. 