### PR TITLE
Remote logging + remote location collection

### DIFF
--- a/open_dread_rando/files/randomizer_powerup.lua
+++ b/open_dread_rando/files/randomizer_powerup.lua
@@ -40,6 +40,7 @@ function RandomizerPowerup.MarkLocationCollected(locationIdentifier)
     local propName = RandomizerPowerup.PropertyForLocation(locationIdentifier)
     Game.LogWarn(0, propName)
     Blackboard.SetProp(playerSection, propName, "b", true)
+    RemoteLua.SendLocationCollected(locationIdentifier)
 end
 
 function RandomizerPowerup.OnPickedUp(actor, progression)

--- a/open_dread_rando/templates/custom_init.lua
+++ b/open_dread_rando/templates/custom_init.lua
@@ -2,9 +2,8 @@ Game.ImportLibrary("system/scripts/init_original.lua")
 
 local initOk, errorMsg = pcall(function()
 
-RemoteLua = RemoteLua or { Init = function() end, }
+RemoteLua = RemoteLua or { Init = function() end, SendLog = function(message) end, SendLocationCollected = function(identifier) end }
 RL = RemoteLua
-RemoteLogHook = false
 
 if TEMPLATE("enable_remote_lua") then
     Game.LogWarn(0, "Starting remote lua")
@@ -29,9 +28,7 @@ local orig_log = Game.LogWarn
 function Game.LogWarn(_, message)
     orig_log(_, message)
     push_debug_print_override()
-    if RemoteLogHook then
-        RemoteLua.SendLog(message)
-    end
+    RemoteLua.SendLog(message)
     pop_debug_print_override()
 end
 

--- a/open_dread_rando/templates/custom_init.lua
+++ b/open_dread_rando/templates/custom_init.lua
@@ -4,6 +4,7 @@ local initOk, errorMsg = pcall(function()
 
 RemoteLua = RemoteLua or { Init = function() end, }
 RL = RemoteLua
+RemoteLogHook = false
 
 if TEMPLATE("enable_remote_lua") then
     Game.LogWarn(0, "Starting remote lua")
@@ -23,6 +24,16 @@ end
 exclude_function_from_logging = exclude_function_from_logging or function(_) end
 push_debug_print_override = push_debug_print_override or function() end
 pop_debug_print_override = pop_debug_print_override or function() end
+
+local orig_log = Game.LogWarn
+function Game.LogWarn(_, message)
+    orig_log(_, message)
+    push_debug_print_override()
+    if RemoteLogHook then
+        RemoteLua.SendLog(message)
+    end
+    pop_debug_print_override()
+end
 
 local orig_update = RemoteLua.Update
 if type(orig_update) == "function" then


### PR DESCRIPTION
Allow remote logging via `remote-dread-lua-conolse` and also can actively tell the cleint if a location is collected.
**New compiled exlaunch needs to be added to this pr**
