### PR TITLE
Support pickups giving a "negative" quantity of an item

### DIFF
--- a/open_dread_rando/files/randomizer_powerup.lua
+++ b/open_dread_rando/files/randomizer_powerup.lua
@@ -28,6 +28,7 @@ function RandomizerPowerup.IncreaseItemAmount(item_id, quantity, capacity)
         end
         target = math.min(target, capacity)
     end
+    target = math.max(target, 0)
     RandomizerPowerup.SetItemAmount(item_id, target)
 end
 
@@ -59,7 +60,7 @@ function RandomizerPowerup.OnPickedUp(actor, progression)
     RandomizerPowerup.CheckArtifacts(granted)
 
     Scenario.UpdateProgressiveItemModels()
-    
+
     return granted
 end
 
@@ -160,13 +161,13 @@ function RandomizerPowerup.IncreaseEnergy(resource)
 
     local new_max = RandomizerPowerup.GetItemAmount("ITEM_MAX_LIFE") + energy
     new_max = math.min(new_max, MAX_ENERGY)
-    
+
     local new_current = new_max
     if item_id == "ITEM_LIFE_SHARDS" and Init.bImmediateEnergyParts then
         new_current = RandomizerPowerup.GetItemAmount("ITEM_CURRENT_LIFE") + energy
         new_current = math.min(new_current, new_max)
     end
-    
+
     RandomizerPowerup.SetItemAmount("ITEM_MAX_LIFE", new_max)
     RandomizerPowerup.SetItemAmount("ITEM_CURRENT_LIFE", new_current)
 
@@ -194,7 +195,7 @@ function RandomizerPowerup.CheckArtifacts(resource)
     if resource == nil then return end
     if Init.iNumRequiredArtifacts == 0 then return end
     if RandomizerPowerup.HasItem("ITEM_METROIDNIZATION") then return end
-    
+
     if resource.item_id:find("ITEM_RANDO_ARTIFACT", 1, true) then
         GUI.AddEmmyMissionLogEntry("#MLOG_"..resource.item_id)
     end

--- a/open_dread_rando/lua_editor.py
+++ b/open_dread_rando/lua_editor.py
@@ -51,7 +51,7 @@ class LuaEditor:
         if actordef_name and len(pickup["model"]) > 1:
             self.add_progressive_models(pickup, actordef_name)
 
-        hashable_progression = "_".join([f'{res["item_id"]}_{res["quantity"]}' for res in pickup_resources])
+        hashable_progression = "_".join([f'{res["item_id"]}_{res["quantity"]}' for res in pickup_resources]).replace("-", "")
 
         if hashable_progression in self._progressive_classes.keys():
             return self._progressive_classes[hashable_progression]

--- a/open_dread_rando/lua_editor.py
+++ b/open_dread_rando/lua_editor.py
@@ -51,7 +51,7 @@ class LuaEditor:
         if actordef_name and len(pickup["model"]) > 1:
             self.add_progressive_models(pickup, actordef_name)
 
-        hashable_progression = "_".join([f'{res["item_id"]}_{res["quantity"]}' for res in pickup_resources]).replace("-", "")
+        hashable_progression = "_".join([f'{res["item_id"]}_{res["quantity"]}' for res in pickup_resources]).replace("-", "MINUS")
 
         if hashable_progression in self._progressive_classes.keys():
             return self._progressive_classes[hashable_progression]


### PR DESCRIPTION
This is a pretty simple change; this fixes an issue in the pickup class generator where the class name would end up containing a hyphen if the pickup grants a negative quantity of something (e.g. missiles), leading to invalid Lua code. The hyphen will now be replaced with "MINUS".

I also added a safety check to make sure you can't get a negative overall quantity of something if you didn't have any of that item and a pickup tried to take some away.