### PR TITLE
Add grapple doors back to door_type enum in schema

### DIFF
--- a/open_dread_rando/files/schema.json
+++ b/open_dread_rando/files/schema.json
@@ -433,6 +433,7 @@
                             "wave_beam",
                             "missile",
                             "super_missile",
+                            "grapple_beam",
                             "ice_missile"
                         ]
                     }


### PR DESCRIPTION
The recent addition of Ice Missile and Diffusion Beam doors seems to have removed Grapple Beam doors from the `schema.json` file, leading to some of the seeds I've generated recently failing to validate (any seed that tries to place a Grapple door will fail, of course).