### PR TITLE
Revert accidental guilib change

### DIFF
--- a/open_dread_rando/files/lua_libraries/guilib.lua
+++ b/open_dread_rando/files/lua_libraries/guilib.lua
@@ -167,12 +167,6 @@ function Container:AddLabel(labelName, labelText, labelProperties)
     return label
 end
 
-function Container:AddText(textName, textText, textProperties)
-    local text = Text(textName, textText, textProperties, self.container)
-    table.insert(self.children, text)
-    return text
-end
-
 function Container:AddSprite(spriteName, spritePath, spriteProperties)
     if spritePath then
         spriteProperties = spriteProperties or {}


### PR DESCRIPTION
I added some changes when I was trying to refactor for room name cosmetic, but reverted most of it when arc found a one-line fix. Forgot to remove this function. 