### PR TITLE
Fix potential game crash when loading a scenario with an upgrade item

### DIFF
--- a/open_dread_rando/pickup.py
+++ b/open_dread_rando/pickup.py
@@ -239,9 +239,11 @@ class ActorPickup(BasePickup):
                 editor.ensure_present(level_pkg, selected_model_data.bmsas)
                 for dep in selected_model_data.dependencies:
                     editor.ensure_present(level_pkg, dep)
+                if selected_model_data.grapple_fx:
+                    # always include Grapple FX particle or the game could crash
+                    editor.ensure_present(level_pkg, "actors/items/powerup_grapplebeam/fx/auraitemparticle.bcptl")
 
-        for pkg in pkgs_for_level:
-            editor.ensure_present(pkg, "actors/items/randomizer_powerup/scripts/randomizer_powerup.lc")
+            editor.ensure_present(level_pkg, "actors/items/randomizer_powerup/scripts/randomizer_powerup.lc")
 
 
 class ActorDefPickup(BasePickup):


### PR DESCRIPTION
The model data for the upgrade items didn't include the "auraitemparticle.bcptl" file like Storms/Grapple/Cross Bombs do, so if that file was not otherwise included in a scenario, the game would crash loading that scenario if there was an upgrade item present. The patcher should include this dependency automatically if `grapple_fx` is true.