### PR TITLE
Fixed bug with super missiles on charge door

### DIFF
--- a/open_dread_rando/door_patcher.py
+++ b/open_dread_rando/door_patcher.py
@@ -137,6 +137,8 @@ class DoorType(Enum):
     WAVE_BEAM = ("wave_beam", ActorData.DOOR_POWER, True, ActorData.SHIELD_WAVE_BEAM)
     MISSILE = ("missile", ActorData.DOOR_POWER, True, ActorData.SHIELD_MISSILE)
     SUPER_MISSILE = ("super_missile", ActorData.DOOR_POWER, True, ActorData.SHIELD_SUPER_MISSILE)
+    SUPER_CHARGE_MISSILE = ("super_charge_missile", ActorData.DOOR_CHARGE, True, 
+                            ActorData.SHIELD_SUPER_MISSILE, True, False)
     ICE_MISSILE = ("ice_missile", ActorData.DOOR_POWER, True, ActorData.SHIELD_ICE_MISSILE, True, True, 
                    ["actors/props/doorshieldmissile"])
     STORM_MISSILE = ("storm_missile", ActorData.DOOR_POWER, True, ActorData.SHIELD_STORM_MISSILE, True, True,


### PR DESCRIPTION
added a SUPER_CHARGE_MISSILE type that uses a charge door base and a super missile cover. Fixes a bug where the door was recognized as a charge door instead of a super missile door. 