### PR TITLE
Use more space for room names

### DIFF
--- a/open_dread_rando/files/lua_libraries/room_names.lua
+++ b/open_dread_rando/files/lua_libraries/room_names.lua
@@ -59,7 +59,7 @@ function RoomNameGui.Init()
     local label = container:AddLabel("RoomNameGui_Text", "Room: Unknown", {
         X = "0.0075",
         Y = "0.01",
-        SizeX = "0.2",
+        SizeX = "0.3",
         SizeY = "0.04",
         Font = "digital_small",
         Autosize = false,


### PR DESCRIPTION
Fixes #223

Just increased the SizeX for the text. `Cold Room (Energy Recharge Station)` is the longest name with 35 characters.

![image](https://github.com/randovania/open-dread-rando/assets/117127188/836022a0-ebab-4eae-b4f4-b91a4490280e)
