### PR TITLE
Add an InventoryIndex

### DIFF
--- a/open_dread_rando/files/randomizer_powerup.lua
+++ b/open_dread_rando/files/randomizer_powerup.lua
@@ -43,6 +43,14 @@ function RandomizerPowerup.MarkLocationCollected(locationIdentifier)
     Blackboard.SetProp(playerSection, propName, "b", true)
 end
 
+function RandomizerPowerup.IncrementInventoryIndex()
+    local playerSection = Game.GetPlayerBlackboardSectionName()
+    local propName = "InventoryIndex"
+    local currentIndex = Blackboard.GetProp(playerSection, propName) or 0
+    currentIndex = currentIndex + 1
+    Blackboard.SetProp(playerSection, propName, "f", currentIndex)
+end
+
 function RandomizerPowerup.OnPickedUp(actor, resources)
     RandomizerPowerup.Self = actor
     local name = "Boss"
@@ -65,6 +73,7 @@ function RandomizerPowerup.OnPickedUp(actor, resources)
 
     RandomizerPowerup.ApplyTunableChanges()
     Scenario.UpdateProgressiveItemModels()
+    RandomizerPowerup.IncrementInventoryIndex()
     RL.UpdateRDVClient(false)
     return granted
 end


### PR DESCRIPTION
Due to the async nature, we can never be sure if a message for remote pickup was calculated on the newest inventory.
This adds an increment for every pickup. The game will eventually reject remote pickups with a wrong inventory index and forces rdv client to resent it.