### PR TITLE
Increase size of linked-list in IPS patches

### DIFF
--- a/open_dread_rando/exefs.py
+++ b/open_dread_rando/exefs.py
@@ -107,14 +107,14 @@ def _add_debug_input(patch: ips.Patch, version: str):
 def _patch_door_lock_buffer(patch: ips.Patch, version: str):
     """ Update capacities in unknown allocator to avoid doorlock crash
     changes size of buffer inside data field initializer (I think)
-    size of linked-list buffer increased from 500 to 700. 
+    size of linked-list buffer increased from 500 to 1000. 
     if 0x33250c in 1.0.0 is crashing, it's likely that this is still too small. 
     original instruction: MOV w2,#0x1f4
-    patched instruction: MOV w2,#0x2bc
+    patched instruction: MOV w2,#0x3e8
     """
     buffer_size = {
-        "1.0.0": (0x00ae6f70, bytes.fromhex('82578052')),
-        "2.1.0": (0x00ae9d70, bytes.fromhex('82578052')),
+        "1.0.0": (0x00ae6f70, bytes.fromhex('027D8052')),
+        "2.1.0": (0x00ae9d70, bytes.fromhex('027D8052')),
     }
 
     offset, data = buffer_size[version]


### PR DESCRIPTION
The reason Door Lock Rando became stable is that a linked-list was overflowing in the executable, so the size was increased from 500 to 700 in February. After receiving [many](https://discord.com/channels/914291389293027329/1107060552259350658) [bug](https://discord.com/channels/914291389293027329/1093586199366598777) [reports](https://discord.com/channels/914291389293027329/1091902924193550407) regarding shuttle/transport crashes, I suspect this may be too low in some cases. 

I don't know how full this buffer gets in vanilla gameplay but I suspect that there is also a separate issue where vanilla assets get unloaded/reloaded as needed while our doorlock shields stay in the buffer permanently. So adding 500 extra map entity slots (250 doors with added shields) should hopefully rule out "too many minimap entities" as a crash cause. 