### PR TITLE
Fixed regression from 2.3.2

### DIFF
--- a/src/open_dread_rando/custom_door_types.py
+++ b/src/open_dread_rando/custom_door_types.py
@@ -46,7 +46,7 @@ class ShieldData:
 ALL_SHIELD_DATA: dict[str, ShieldData] = {
     "ice_missile": ShieldData(
         name="doorshieldicemissile",
-        type=DoorTemplates.TRIANGLES,
+        type=DoorTemplates.HEXAGONS,
         weaknesses=["ICE_MISSILE"],
         actordef="actors/props/doorshieldicemissile/charclasses/doorshieldicemissile.bmsad",
         default_mdl=ModelData(

--- a/src/open_dread_rando/door_patcher.py
+++ b/src/open_dread_rando/door_patcher.py
@@ -145,9 +145,9 @@ class DoorType(Enum):
     BOMB = ("bomb", ActorData.DOOR_POWER, True, ActorData.SHIELD_BOMB, True, True,
             ["actors/props/doorshieldmissile", "actors/props/doorshieldsupermissile"])
     CROSS_BOMB = ("cross_bomb", ActorData.DOOR_POWER, True, ActorData.SHIELD_CROSS_BOMB, True, True,
-                  ["actors/props/doorshieldmissile"])
+                  ["actors/props/doorshieldmissile", "actors/props/doorshieldsupermissile"])
     POWER_BOMB = ("power_bomb", ActorData.DOOR_POWER, True, ActorData.SHIELD_POWER_BOMB, True, True,
-                  ["actors/props/door_shield_plasma"])
+                  ["actors/props/doorshieldmissile", "actors/props/doorshieldsupermissile"])
     GRAPPLE = ("grapple_beam", ActorData.DOOR_GRAPPLE, False, None, True, True,
                ["actors/props/door"])
     PRESENCE = ("phantom_cloak", ActorData.DOOR_PRESENCE, False, None, True, False,


### PR DESCRIPTION
Ice Missile shield was accidentally changed to use a super missile actordef without making the asset depend on super missiles, causing issues in Cataris. This patch resolves this and also an issue where bomb-based doors didn't depend on super missiles. 

bug report: https://discord.com/channels/914291389293027329/1136933267979899011