### PR TITLE
Bomb Shields require normal bombs to open

### DIFF
--- a/src/open_dread_rando/door_locks/custom_door_types.py
+++ b/src/open_dread_rando/door_locks/custom_door_types.py
@@ -199,7 +199,8 @@ ALL_SHIELD_DATA: dict[str, ShieldData] = {
     "bomb": ShieldData(
         name="doorshieldbomb",
         type=DoorTemplates.TRIANGLES,
-        weaknesses=["BOMB"],
+        weaknesses=[], # "BOMB" weakness is added in runtime lua.
+                       # see open_dread_rando/files/custom_scenario.lua : Scenario._BlastShieldTypes
         collision="actors/props/doorshieldmissile/collisions/shield_bomb_colls.bmscd",
         actordef="actors/props/doorshieldbomb/charclasses/doorshieldbomb.bmsad",
         default_mdl=ModelData(

--- a/src/open_dread_rando/files/custom_scenario.lua
+++ b/src/open_dread_rando/files/custom_scenario.lua
@@ -238,6 +238,10 @@ Scenario._BlastShieldTypes = {
     door_shield_plasma = {
         item = "ITEM_WEAPON_PLASMA_BEAM",
         damage = {"PLASMA_BEAM"}
+    },
+    doorshieldbomb = {
+        item = "ITEM_WEAPON_BOMB",
+        damage = {"BOMB"}
     }
 }
 function Scenario._UpdateBlastShields()


### PR DESCRIPTION
- Added a check to the lua to add weaknesses to bomb shields only when ITEM_WEAPON_BOMB is in player's inventory
- Removed the BOMB weakness in custom_door_locks.py with a comment directing developers to the lua