### PR TITLE
Added a game patch to nerf power bombs

### DIFF
--- a/src/open_dread_rando/files/schema.json
+++ b/src/open_dread_rando/files/schema.json
@@ -475,6 +475,11 @@
                     "type": "boolean",
                     "description": "Enable warping to the starting location from Save Stations.",
                     "default": true
+                },
+                "nerf_power_bombs": {
+                    "type": "boolean",
+                    "description": "Changes weaknesses for certain enemies and props to make Power Bombs less overpowered.",
+                    "default": false
                 }
             },
             "additionalProperties": false

--- a/src/open_dread_rando/specific_patches/game_patches.py
+++ b/src/open_dread_rando/specific_patches/game_patches.py
@@ -28,6 +28,9 @@ def apply_game_patches(editor: PatcherEditor, configuration: dict):
     if configuration["warp_to_start"]:
         _warp_to_start(editor)
 
+    if configuration["nerf_power_bombs"]:
+        _remove_pb_weaknesses(editor)
+
 
 def _modify_raven_beak_damage_table(editor: PatcherEditor, mode: str):
     rb_bmsad = editor.get_file("actors/characters/chozocommander/charclasses/chozocommander.bmsad", Bmsad)
@@ -95,6 +98,22 @@ def _remove_grapple_blocks(editor: PatcherEditor, configuration: dict):
             },
             "mapProps"
         )
+
+
+def _remove_pb_weaknesses(editor: PatcherEditor):
+    # enky
+    warlotus = editor.get_file("actors/characters/warlotus/charclasses/warlotus.bmsad", Bmsad)
+    warlotus.raw.property.components.LIFE.fields.fields.bShouldDieWithPowerBomb = False
+    warlotus.raw.property.components.LIFE.fields.fields.oDamageSourceFactor.fPowerBombFactor = 0.0
+
+    # charge door
+    for door in ["doorchargecharge", "doorchargeclosed", "doorclosedcharge"]:
+        charge_door = editor.get_file(f"actors/props/{door}/charclasses/{door}.bmsad", Bmsad)
+        func = charge_door.raw.property.components.LIFE.functions[0]
+        if func.params.Param1.value:
+            func.params.Param1.value = "CHARGE_BEAM"
+        if func.params.Param2.value:
+            func.params.Param2.value = "CHARGE_BEAM"
 
 
 def _warp_to_start(editor: PatcherEditor):


### PR DESCRIPTION
config.game_patches.nerf_power_bomb is a new option that removes power bomb's ability to destroy Enky and open Charge Beam doors, making the Ice Missile and Charge Beam upgrades much more useful. This also allows the player to use increased Knowledge trick levels without making Ice Missiles a non-progression item. 