### PR TITLE
Progress counter fixed

### DIFF
--- a/src/open_dread_rando/files/custom_scenario.lua
+++ b/src/open_dread_rando/files/custom_scenario.lua
@@ -21,6 +21,18 @@ Scenario.tRandoHintPropIDs = {
     SHIP_1 = Blackboard.RegisterLUAProp("HINT_SHIP_1", "bool")
 }
 
+Scenario.tNumTanksMaxByScenario = {
+    s010_cave = 35,
+    s020_magma = 25,
+    s030_baselab = 23,
+    s040_aqua = 20,
+    s050_forest = 20,
+    s060_quarantine = 5,
+    s070_basesanc = 17,
+    s080_shipyard = 4,
+    s090_skybase = 0
+}
+
 Scenario.RandoTrueXRelease = Blackboard.RegisterLUAProp("X_RELEASE_TRUE", "bool")
 
 Scenario.INVALID_UUID = "00000000-0000-1111-0000-000000000000"
@@ -116,6 +128,8 @@ function Scenario.InitScenario(arg1, arg2, arg3, arg4)
     if Init.bEnableDeathCounter then
         DeathCounter.OnScenarioInitialized()
     end
+
+    Game.AddSF(1.0, "Scenario.UpdateNumTanksMax", "i", Scenario.tNumTanksMaxByScenario[CurrentScenarioID])
 end
 
 local fatal_messages_seen = 0
@@ -478,13 +492,13 @@ function Scenario.UpdateRoomName(new_subarea)
     RoomNameGui.Update(new_subarea)
 end
 
-function Scenario.Rando_SetAreaLocations(num_locs)
+function Scenario.UpdateNumTanksMax(num_locs)
     -- sets Scenario blackboard NumTanksPickedUpMax to num_locs
     Game.LogWarn(0, "Setting " .. CurrentScenarioID .. ".NumTanksPickedUpMax = " .. num_locs)
     Scenario.WriteToBlackboard("NumTanksPickedUpMax", "i", num_locs)
 end
 
-function Scenario.Rando_IncrementCompletion()
+function Scenario.IncrementCompletion()
     -- increment global NumTanksPickedUp
     local global_itemcount = Scenario.GetBlackboardProp("GAME", "NumTanksPickedUp")
     if global_itemcount == nil then -- if its the first pickup its uninitialized

--- a/src/open_dread_rando/files/custom_scenario.lua
+++ b/src/open_dread_rando/files/custom_scenario.lua
@@ -500,15 +500,12 @@ end
 
 function Scenario.IncrementCompletion()
     -- increment global NumTanksPickedUp
-    local global_itemcount = Scenario.GetBlackboardProp("GAME", "NumTanksPickedUp")
-    if global_itemcount == nil then -- if its the first pickup its uninitialized
-        global_itemcount = 0
-    end
+    local global_itemcount = Scenario.GetBlackboardProp("GAME", "NumTanksPickedUp", 0)
     global_itemcount = global_itemcount + 1
     Scenario.SetBlackboardProp("GAME", "NumTanksPickedUp", "i", global_itemcount)
 
     -- update global completion number (the "percent" which is stored as an int for reasons unknown)
-    Scenario.SetBlackboardProp("GAME", "Completion", "i", math.floor(global_itemcount * 100 / 149))
+    Scenario.SetBlackboardProp("GAME", "Completion", "i", math.floor(global_itemcount / 149 * 100))
 
     -- increment local NumTanksPickedUp
     local area_itemcount = Scenario.ReadFromBlackboard("NumTanksPickedUp", 0)

--- a/src/open_dread_rando/files/custom_scenario.lua
+++ b/src/open_dread_rando/files/custom_scenario.lua
@@ -477,3 +477,26 @@ end
 function Scenario.UpdateRoomName(new_subarea)
     RoomNameGui.Update(new_subarea)
 end
+
+function Scenario.Rando_SetAreaLocations(num_locs)
+    -- sets Scenario blackboard NumTanksPickedUpMax to num_locs
+    Game.LogWarn(0, "Setting " .. CurrentScenarioID .. ".NumTanksPickedUpMax = " .. num_locs)
+    Scenario.WriteToBlackboard("NumTanksPickedUpMax", "i", num_locs)
+end
+
+function Scenario.Rando_IncrementCompletion()
+    -- increment global NumTanksPickedUp
+    local global_itemcount = Scenario.GetBlackboardProp("GAME", "NumTanksPickedUp")
+    if global_itemcount == nil then -- if its the first pickup its uninitialized
+        global_itemcount = 0
+    end
+    global_itemcount = global_itemcount + 1
+    Scenario.SetBlackboardProp("GAME", "NumTanksPickedUp", "i", global_itemcount)
+
+    -- update global completion number (the "percent" which is stored as an int for reasons unknown)
+    Scenario.SetBlackboardProp("GAME", "Completion", "i", math.floor(global_itemcount * 100 / 149))
+
+    -- increment local NumTanksPickedUp
+    local area_itemcount = Scenario.ReadFromBlackboard("NumTanksPickedUp", 0)
+    Scenario.WriteToBlackboard("NumTanksPickedUp", "i", area_itemcount + 1)
+end

--- a/src/open_dread_rando/files/levels/s010_cave.lc.lua
+++ b/src/open_dread_rando/files/levels/s010_cave.lc.lua
@@ -143,8 +143,6 @@ function s010_cave.InitFromBlackboard()
   if not CAVES_GAME_INTRO then
     s010_cave.OnEnd_Cutscene_intro_end()
   end
-
-  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 35) -- EMMI-02SM and Corpius
 end
 
 
@@ -240,7 +238,7 @@ function s010_cave.OnEmmyAbilityObtainedFadeOutCompleted()
     L2_2.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
   end
 
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end
 
 
@@ -2300,5 +2298,5 @@ function s010_cave.cutsceneplayer_57_delayed()
 end
 
 function s010_cave.OnCorpiusDeath_CUSTOM()
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end

--- a/src/open_dread_rando/files/levels/s010_cave.lc.lua
+++ b/src/open_dread_rando/files/levels/s010_cave.lc.lua
@@ -143,6 +143,8 @@ function s010_cave.InitFromBlackboard()
   if not CAVES_GAME_INTRO then
     s010_cave.OnEnd_Cutscene_intro_end()
   end
+
+  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 35) -- EMMI-02SM and Corpius
 end
 
 
@@ -237,6 +239,8 @@ function s010_cave.OnEmmyAbilityObtainedFadeOutCompleted()
   if L2_2 ~= nil then
     L2_2.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
   end
+
+  Scenario.Rando_IncrementCompletion()
 end
 
 
@@ -2296,4 +2300,5 @@ function s010_cave.cutsceneplayer_57_delayed()
 end
 
 function s010_cave.OnCorpiusDeath_CUSTOM()
+  Scenario.Rando_IncrementCompletion()
 end

--- a/src/open_dread_rando/files/levels/s020_magma.lc.lua
+++ b/src/open_dread_rando/files/levels/s020_magma.lc.lua
@@ -98,6 +98,8 @@ function s020_magma.InitFromBlackboard()
       oActor2.MODELUPDATER:SetMeshVisible("Slime_MESH", false)
     end
   end
+
+  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 25) -- EMMI-03MB, Kraid and Experiment
 end
 
 
@@ -169,6 +171,8 @@ function s020_magma.OnEmmyAbilityObtainedFadeOutCompleted()
     oActor.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
     oActor.CENTRALUNIT:UnlockDoors()
   end
+
+  Scenario.Rando_IncrementCompletion()
 end
 
 
@@ -877,6 +881,7 @@ function s020_magma.OnCutscene81Ended()
 end
 
 function s020_magma.OnExperimentDeath_CUSTOM()
+  Scenario.Rando_IncrementCompletion()
 end
 
 function s020_magma.OnCutscene81Skipped()
@@ -1055,6 +1060,7 @@ end
 
 function s020_magma.OnKraidDeath_CUSTOM()
   Game.AddGUISF(0, "s020_magma.Kraid_Activation_Stage_03_CutsceneEnd", "")
+  Scenario.Rando_IncrementCompletion()
 end
 
 function s020_magma.IsKraidCombatBegin(old_subarea, old_actorgroup, new_subarea, new_actorgroup, disable_fade)

--- a/src/open_dread_rando/files/levels/s020_magma.lc.lua
+++ b/src/open_dread_rando/files/levels/s020_magma.lc.lua
@@ -98,8 +98,6 @@ function s020_magma.InitFromBlackboard()
       oActor2.MODELUPDATER:SetMeshVisible("Slime_MESH", false)
     end
   end
-
-  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 25) -- EMMI-03MB, Kraid and Experiment
 end
 
 
@@ -172,7 +170,7 @@ function s020_magma.OnEmmyAbilityObtainedFadeOutCompleted()
     oActor.CENTRALUNIT:UnlockDoors()
   end
 
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end
 
 
@@ -881,7 +879,7 @@ function s020_magma.OnCutscene81Ended()
 end
 
 function s020_magma.OnExperimentDeath_CUSTOM()
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end
 
 function s020_magma.OnCutscene81Skipped()
@@ -1060,7 +1058,7 @@ end
 
 function s020_magma.OnKraidDeath_CUSTOM()
   Game.AddGUISF(0, "s020_magma.Kraid_Activation_Stage_03_CutsceneEnd", "")
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end
 
 function s020_magma.IsKraidCombatBegin(old_subarea, old_actorgroup, new_subarea, new_actorgroup, disable_fade)

--- a/src/open_dread_rando/files/levels/s030_baselab.lc.lua
+++ b/src/open_dread_rando/files/levels/s030_baselab.lc.lua
@@ -81,8 +81,6 @@ function s030_baselab.InitFromBlackboard()
   if QUARENTINE_OPENED == true then
     s030_baselab.Activate_Setup_PostXRelease()
   end
-
-  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 23) -- incl. EMMI-04SB
 end
 
 function s030_baselab.Activate_Setup_PostXRelease()
@@ -217,7 +215,7 @@ function s030_baselab.OnEmmyAbilityObtainedFadeOutCompleted()
     oActor.CENTRALUNIT:UnlockDoors()
   end
 
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end
 
 

--- a/src/open_dread_rando/files/levels/s030_baselab.lc.lua
+++ b/src/open_dread_rando/files/levels/s030_baselab.lc.lua
@@ -81,6 +81,8 @@ function s030_baselab.InitFromBlackboard()
   if QUARENTINE_OPENED == true then
     s030_baselab.Activate_Setup_PostXRelease()
   end
+
+  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 23) -- incl. EMMI-04SB
 end
 
 function s030_baselab.Activate_Setup_PostXRelease()
@@ -214,6 +216,8 @@ function s030_baselab.OnEmmyAbilityObtainedFadeOutCompleted()
     oActor.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
     oActor.CENTRALUNIT:UnlockDoors()
   end
+
+  Scenario.Rando_IncrementCompletion()
 end
 
 

--- a/src/open_dread_rando/files/levels/s040_aqua.lc.lua
+++ b/src/open_dread_rando/files/levels/s040_aqua.lc.lua
@@ -74,8 +74,6 @@ function s040_aqua.InitFromBlackboard()
     s040_aqua.Activate_Setup_PostXRelease()
   end
   s040_aqua.DisableAllWaterPools()
-
-  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 20) -- Drogyga
 end
 
 function s040_aqua.Activate_Setup_PostXRelease()
@@ -359,7 +357,7 @@ function s040_aqua.OnHydrogigaDead(_ARG_0_, _ARG_1_)
 
   Scenario.WriteToBlackboard(Scenario.LUAPropIDs.HYDROGIGA_DEAD, "b", true)
   s040_aqua.CheckHydrogiga()
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end
 
 function s040_aqua.OnHydrogigaDead_CUSTOM()

--- a/src/open_dread_rando/files/levels/s040_aqua.lc.lua
+++ b/src/open_dread_rando/files/levels/s040_aqua.lc.lua
@@ -74,6 +74,8 @@ function s040_aqua.InitFromBlackboard()
     s040_aqua.Activate_Setup_PostXRelease()
   end
   s040_aqua.DisableAllWaterPools()
+
+  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 20) -- Drogyga
 end
 
 function s040_aqua.Activate_Setup_PostXRelease()
@@ -357,6 +359,7 @@ function s040_aqua.OnHydrogigaDead(_ARG_0_, _ARG_1_)
 
   Scenario.WriteToBlackboard(Scenario.LUAPropIDs.HYDROGIGA_DEAD, "b", true)
   s040_aqua.CheckHydrogiga()
+  Scenario.Rando_IncrementCompletion()
 end
 
 function s040_aqua.OnHydrogigaDead_CUSTOM()

--- a/src/open_dread_rando/files/levels/s050_forest.lc.lua
+++ b/src/open_dread_rando/files/levels/s050_forest.lc.lua
@@ -71,6 +71,8 @@ function s050_forest.InitFromBlackboard()
   if QUARENTINE_OPENED == true then
     s050_forest.Activate_Setup_PostXRelease()
   end
+
+  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 20) -- EMMI-05IM and Golzuna
 end
 
 function s050_forest.Activate_Setup_PostXRelease()
@@ -395,6 +397,8 @@ function s050_forest.OnEmmyAbilityObtainedFadeOutCompleted()
     oActor.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
     oActor.CENTRALUNIT:UnlockDoors()
   end
+
+  Scenario.Rando_IncrementCompletion()
 end
 
 

--- a/src/open_dread_rando/files/levels/s050_forest.lc.lua
+++ b/src/open_dread_rando/files/levels/s050_forest.lc.lua
@@ -396,7 +396,7 @@ function s050_forest.OnEmmyAbilityObtainedFadeOutCompleted()
     oActor.CENTRALUNIT:UnlockDoors()
   end
 
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end
 
 

--- a/src/open_dread_rando/files/levels/s050_forest.lc.lua
+++ b/src/open_dread_rando/files/levels/s050_forest.lc.lua
@@ -71,8 +71,6 @@ function s050_forest.InitFromBlackboard()
   if QUARENTINE_OPENED == true then
     s050_forest.Activate_Setup_PostXRelease()
   end
-
-  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 20) -- EMMI-05IM and Golzuna
 end
 
 function s050_forest.Activate_Setup_PostXRelease()

--- a/src/open_dread_rando/files/levels/s070_basesanc.lc.lua
+++ b/src/open_dread_rando/files/levels/s070_basesanc.lc.lua
@@ -85,8 +85,6 @@ function s070_basesanc.InitFromBlackboard()
       L0_2.bEnabled = false
     end
   end
-
-  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 17) -- EMMI-06WB and Escue
 end
 
 function s070_basesanc.Activate_Setup_PostXRelease()
@@ -414,7 +412,7 @@ function s070_basesanc.OnEmmyAbilityObtainedFadeOutCompleted()
     L0_2.CENTRALUNIT:UnlockDoors()
   end
 
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end
 
 

--- a/src/open_dread_rando/files/levels/s070_basesanc.lc.lua
+++ b/src/open_dread_rando/files/levels/s070_basesanc.lc.lua
@@ -85,6 +85,8 @@ function s070_basesanc.InitFromBlackboard()
       L0_2.bEnabled = false
     end
   end
+
+  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 17) -- EMMI-06WB and Escue
 end
 
 function s070_basesanc.Activate_Setup_PostXRelease()
@@ -411,6 +413,8 @@ function s070_basesanc.OnEmmyAbilityObtainedFadeOutCompleted()
     L0_2.CENTRALUNIT:OnEmmyAbilityObtainedFadeOutCompleted()
     L0_2.CENTRALUNIT:UnlockDoors()
   end
+
+  Scenario.Rando_IncrementCompletion()
 end
 
 

--- a/src/open_dread_rando/files/levels/s080_shipyard.lc.lua
+++ b/src/open_dread_rando/files/levels/s080_shipyard.lc.lua
@@ -35,8 +35,6 @@ function s080_shipyard.InitFromBlackboard()
   if oProp ~= nil and oProp > 0 then
     s080_shipyard.Activate_Setup_WaveBeamAcquired()
   end
-
-  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 4) -- EMMI-07PB
 end
 
 function s080_shipyard.Activate_Setup_WaveBeamAcquired()
@@ -286,7 +284,7 @@ function s080_shipyard.OnEmmyShipyardAbilityObtained()
 
   Game.AddSF(0.8, "s080_shipyard.OpenEmmyValves", "")
 
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end
 
 

--- a/src/open_dread_rando/files/levels/s080_shipyard.lc.lua
+++ b/src/open_dread_rando/files/levels/s080_shipyard.lc.lua
@@ -35,6 +35,8 @@ function s080_shipyard.InitFromBlackboard()
   if oProp ~= nil and oProp > 0 then
     s080_shipyard.Activate_Setup_WaveBeamAcquired()
   end
+
+  Game.AddSF(1.0, "Scenario.Rando_SetAreaLocations", "i", 4) -- EMMI-07PB
 end
 
 function s080_shipyard.Activate_Setup_WaveBeamAcquired()
@@ -283,6 +285,8 @@ end
 function s080_shipyard.OnEmmyShipyardAbilityObtained()
 
   Game.AddSF(0.8, "s080_shipyard.OpenEmmyValves", "")
+
+  Scenario.Rando_IncrementCompletion()
 end
 
 

--- a/src/open_dread_rando/files/templates/custom_core_x.lua
+++ b/src/open_dread_rando/files/templates/custom_core_x.lua
@@ -15,5 +15,7 @@ function CoreX_SuperGoliath.OnBigXAbsorbed(A0_2)
   if actor ~= nil then
     actor.LIFE:UnLockDoor()
   end
-  Game.SaveGame("checkpoint", "SuperGoliath_Dead", "SP_Checkpoint_LineBomb", true) 
+  Game.SaveGame("checkpoint", "SuperGoliath_Dead", "SP_Checkpoint_LineBomb", true)
+
+  Scenario.Rando_IncrementCompletion()
 end

--- a/src/open_dread_rando/files/templates/custom_core_x.lua
+++ b/src/open_dread_rando/files/templates/custom_core_x.lua
@@ -17,5 +17,5 @@ function CoreX_SuperGoliath.OnBigXAbsorbed(A0_2)
   end
   Game.SaveGame("checkpoint", "SuperGoliath_Dead", "SP_Checkpoint_LineBomb", true)
 
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end

--- a/src/open_dread_rando/files/templates/custom_core_x_superquetzoa.lua
+++ b/src/open_dread_rando/files/templates/custom_core_x_superquetzoa.lua
@@ -18,5 +18,5 @@ function CoreX_SuperQuetzoa.OnBigXAbsorbed(_ARG_0_)
   end
   Game.SaveGame("checkpoint", "SuperQuetzoa_Dead", "SP_Checkpoint_MultiLockOn", true)
 
-  Scenario.Rando_IncrementCompletion()
+  Scenario.IncrementCompletion()
 end

--- a/src/open_dread_rando/files/templates/custom_core_x_superquetzoa.lua
+++ b/src/open_dread_rando/files/templates/custom_core_x_superquetzoa.lua
@@ -17,4 +17,6 @@ function CoreX_SuperQuetzoa.OnBigXAbsorbed(_ARG_0_)
     door.LIFE:UnLockDoor()
   end
   Game.SaveGame("checkpoint", "SuperQuetzoa_Dead", "SP_Checkpoint_MultiLockOn", true)
+
+  Scenario.Rando_IncrementCompletion()
 end

--- a/src/open_dread_rando/files/templates/custom_init.lua
+++ b/src/open_dread_rando/files/templates/custom_init.lua
@@ -71,6 +71,10 @@ Init.sStartingScenario = TEMPLATE("starting_scenario")
 Init.sStartingActor = TEMPLATE("starting_actor")
 Init.sLayoutUUID = TEMPLATE("layout_uuid")
 
+Init.tMaxGameProgressStats = {
+    NumTanksPickedUp = 149
+}
+
 function Game.StartPrologue(arg1, arg2, arg3, arg4, arg5)
     Game.LogWarn(0, string.format("Will start Game - %s / %s / %s / %s", tostring(arg1), tostring(arg2), tostring(arg3), tostring(arg4)))
     Game.LoadScenario("c10_samus", Init.sStartingScenario, Init.sStartingActor, "", 1)


### PR DESCRIPTION
Global and regional progress counters (item %'s) are fixed to accurately count item checks. The save file is based on a maximum of 149 items instead of 123, and each area sets its correct item count (including all actor pickups and boss pickups). Bosses use an added scenario function to increment the item counters, making them behave like regular checks. 

Fixes #61 