### PR TITLE
Regression fixes

### DIFF
--- a/src/open_dread_rando/pickups/pickup.py
+++ b/src/open_dread_rando/pickups/pickup.py
@@ -100,7 +100,7 @@ class ActorPickup(BasePickup):
         script.functions[0].set_param(2, self.lua_editor.get_script_class(self.pickup))
 
         set_custom.set_param(1, item_id)
-        set_custom.set_param(2, quantity)
+        set_custom.set_param(2, float(quantity))
 
         return bmsad
 
@@ -141,6 +141,7 @@ class ActorPickup(BasePickup):
                 components = new_template.components
                 components["MATERIALFX"] = grapple_components["MATERIALFX"]
                 components["FX"] = grapple_components["FX"]
+                new_template.components = components
 
             if selected_model_data.transform is not None:
                 model_updater.fields.vInitScale = list(selected_model_data.transform.scale)


### PR DESCRIPTION
Grapple FX are added to the bmsad by adding a `MATERIALFX` and `FX` component. They will not end up in the bmsad as MEDS is now returning a new dict via the components property. Just editing it will not be sufficient anymore.
I just used the setter now. I think that's probably very unoptimized? Alternatively we could directly access the raw:
```
                grapple_components = grapple.raw["components"]
                components = new_template.raw["components"]
                components["MATERIALFX"] = grapple_components["MATERIALFX"]
                components["FX"] = grapple_components["FX"]
```

Param 2 needs to be a float for the pickups to work. Integer doesn't give you the item at all (see issue where you collect the item but don't get it)

Fixes #272