### PR TITLE
Clarify license for dread-depackager/exlaunch

### DIFF
--- a/src/open_dread_rando/files/dread_depackager/README.md
+++ b/src/open_dread_rando/files/dread_depackager/README.md
@@ -1,4 +1,4 @@
-`dread_depackager` created by *stuckpixel*, forked from `exlaunch` by *shadowninja108*. Licensed GPL v2.0. 
+`dread_depackager` created by *stuckpixel*, forked from `exlaunch` by *shadowninja108*. Licensed GPL v2.0 or later. 
 
 More details: https://github.com/pixel-stuck/exlaunch/blob/main/LICENSE
 


### PR DESCRIPTION
dread-depackager/exlaunch are actually licensed under GPLv2+ (/ or later). As seen [here](https://github.com/shadowninja108/exlaunch/blob/main/LICENSE#L299) for exlaunch and [here](https://github.com/pixel-stuck/exlaunch/blob/main/LICENSE#L299) for dread-depackager.
Worth pointing out, as pure GPLv2 is incompatible with GPLv3.