### PR TITLE
Move item_missiletank_000 to the left by 200

### DIFF
--- a/src/open_dread_rando/specific_patches/static_fixes.py
+++ b/src/open_dread_rando/specific_patches/static_fixes.py
@@ -2,7 +2,7 @@ import copy
 from typing import Optional
 
 import construct
-from mercury_engine_data_structures.formats import Brfld
+from mercury_engine_data_structures.formats import Bmmap, Brfld
 from mercury_engine_data_structures.formats.gui_files import Bmscp
 
 from open_dread_rando.constants import ALL_SCENARIOS
@@ -364,6 +364,20 @@ def fix_map_icons(map_editor: MapIconEditor):
     map_editor.mirror_bmmap_icons()
 
 
+def move_artaria_missile_tank(editor: PatcherEditor):
+    actor_ref = {
+        "scenario": "s010_cave",
+        "layer": "default",
+        "actor": "item_missiletank_000"
+    }
+    missile_tank = editor.resolve_actor_reference(actor_ref)
+    artaria_map = editor.get_scenario_file(actor_ref["scenario"], Bmmap)
+
+    new_x_pos = 15450.0
+    missile_tank.vPos[0] = new_x_pos
+    artaria_map.items[actor_ref["actor"]].vPos[0] = new_x_pos
+
+
 def apply_static_fixes(editor: PatcherEditor):
     remove_problematic_x_layers(editor)
     activate_emmi_zones(editor)
@@ -377,3 +391,4 @@ def apply_static_fixes(editor: PatcherEditor):
     apply_main_menu_fixes(editor)
     disable_hanubia_cutscene(editor)
     fix_map_icons(editor.map_icon_editor)
+    move_artaria_missile_tank(editor)


### PR DESCRIPTION
In door lock the item can be badly visible like here in a screenshot from XenoWars:
![image](https://github.com/randovania/open-dread-rando/assets/117127188/a4ff1e13-c945-4b0b-a314-80b59491fae3)

I moved it a little bit to the left:
![image](https://github.com/randovania/open-dread-rando/assets/117127188/70e6cc6e-43b7-4c47-895f-381e62b23c1a)
![image](https://github.com/randovania/open-dread-rando/assets/117127188/1be8bf4f-3871-466e-9f49-d07c0f896c4c)
