### PR TITLE
Add new field for tunables to patcher.json

### DIFF
--- a/src/open_dread_rando/cosmetic_patches/__init__.py
+++ b/src/open_dread_rando/cosmetic_patches/__init__.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from open_dread_rando.misc_patches.tunable_patcher import apply_tunable_patches
 from open_dread_rando.patcher_editor import PatcherEditor
 

--- a/src/open_dread_rando/cosmetic_patches/__init__.py
+++ b/src/open_dread_rando/cosmetic_patches/__init__.py
@@ -1,17 +1,8 @@
 from typing import Any
 
-from mercury_engine_data_structures.formats.ini import Ini
-
+from open_dread_rando.misc_patches.tunable_patcher import apply_tunable_patches
 from open_dread_rando.patcher_editor import PatcherEditor
 
 
 def apply_cosmetic_patches(editor: PatcherEditor, cosmetic: dict):
-    edit_config(editor, cosmetic["config"])
-
-
-def edit_config(editor: PatcherEditor, config_patches: dict[str, dict[str, Any]]):
-    config_file = editor.get_file('config.ini', Ini)
-
-    for section, items in config_patches.items():
-        for k, v in items.items():
-            config_file.config[section][k] = Ini.parse_option(v)
+    apply_tunable_patches(editor, cosmetic["config"])

--- a/src/open_dread_rando/dread_patcher.py
+++ b/src/open_dread_rando/dread_patcher.py
@@ -20,6 +20,7 @@ from open_dread_rando.misc_patches.model_patcher import generate_custom_models
 from open_dread_rando.misc_patches.sprite_patches import patch_sprites
 from open_dread_rando.misc_patches.text_patches import apply_text_patches, patch_credits, patch_hints, patch_text
 from open_dread_rando.misc_patches.tilegroup_patcher import patch_tilegroup
+from open_dread_rando.misc_patches.tunable_patcher import apply_tunable_patches
 from open_dread_rando.output_config import output_format_for_category, output_paths_for_compatibility
 from open_dread_rando.patcher_editor import PatcherEditor
 from open_dread_rando.pickups.lua_editor import LuaEditor
@@ -256,6 +257,10 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     # Cosmetic patches
     if "cosmetic_patches" in configuration:
         apply_cosmetic_patches(editor, configuration["cosmetic_patches"])
+
+    # Tunable patches
+    if "tunables" in configuration:
+        apply_tunable_patches(editor, configuration["tunables"])
 
     # Environmental Damage
     apply_constant_damage(editor, configuration["constant_environment_damage"])

--- a/src/open_dread_rando/files/schema.json
+++ b/src/open_dread_rando/files/schema.json
@@ -422,6 +422,9 @@
                 "shield_versions"
             ]
         },
+        "tunables": {
+            "type": "object"
+        },
         "enable_remote_lua": {
             "type": "boolean",
             "default": false,

--- a/src/open_dread_rando/files/schema.json
+++ b/src/open_dread_rando/files/schema.json
@@ -428,8 +428,15 @@
             "additionalProperties": false,
             "default": {},
             "patternProperties": {
-                ".*": {
-                    "type": "object"
+                "^[a-zA-Z]+$": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "default": {},
+                    "patternProperties": {
+                        "^[a-zA-Z0-9_]+$": {
+                            "type": ["number", "boolean", "string"]
+                        }
+                    }
                 }
             }
         },

--- a/src/open_dread_rando/files/schema.json
+++ b/src/open_dread_rando/files/schema.json
@@ -423,7 +423,15 @@
             ]
         },
         "tunables": {
-            "type": "object"
+            "type": "object",
+            "description": "Non-cosmetic tunables to be patched, applied after cosmetic patches",
+            "additionalProperties": false,
+            "default": {},
+            "patternProperties": {
+                ".*": {
+                    "type": "object"
+                }
+            }
         },
         "enable_remote_lua": {
             "type": "boolean",

--- a/src/open_dread_rando/misc_patches/tunable_patcher.py
+++ b/src/open_dread_rando/misc_patches/tunable_patcher.py
@@ -10,5 +10,6 @@ def apply_tunable_patches(editor: PatcherEditor, tunable_patches: dict[str, dict
 
     for section, items in tunable_patches.items():
         for k, v in items.items():
-            if section not in config_file.config: config_file.config[section] = {}
+            if section not in config_file.config:
+                config_file.config[section] = {}
             config_file.config[section][k] = Ini.parse_option(v)

--- a/src/open_dread_rando/misc_patches/tunable_patcher.py
+++ b/src/open_dread_rando/misc_patches/tunable_patcher.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from mercury_engine_data_structures.formats.ini import Ini
+
+from open_dread_rando.patcher_editor import PatcherEditor
+
+
+def apply_tunable_patches(editor: PatcherEditor, tunable_patches: dict[str, dict[str, Any]]):
+    config_file = editor.get_file('config.ini', Ini)
+
+    for section, items in tunable_patches.items():
+        for k, v in items.items():
+            config_file.config[section][k] = Ini.parse_option(v)

--- a/src/open_dread_rando/misc_patches/tunable_patcher.py
+++ b/src/open_dread_rando/misc_patches/tunable_patcher.py
@@ -10,4 +10,5 @@ def apply_tunable_patches(editor: PatcherEditor, tunable_patches: dict[str, dict
 
     for section, items in tunable_patches.items():
         for k, v in items.items():
+            if section not in config_file.config: config_file.config[section] = {}
             config_file.config[section][k] = Ini.parse_option(v)

--- a/tests/test_files/april_fools_patcher.json
+++ b/tests/test_files/april_fools_patcher.json
@@ -4029,6 +4029,11 @@
             "power_bomb": "ALTERNATE"
         }
     },
+    "tunables": {
+        "AbilityOpticCamouflage": {
+            "iSelectionMode": 1
+        }
+    },
     "energy_per_tank": 100,
     "immediate_energy_parts": true,
     "enable_remote_lua": true,


### PR DESCRIPTION
- New field in patcher.json called `tunables`
- New tunable patcher (btunda integration will be added in a later PR)
- `cosmetic_patches.config` still exists to help avoid conflicts when using Randovania's `custom_patcher_data`
    - Cosmetic patches now invoke the tunable patcher