### PR TITLE
Add thermal door before Z-57 morph launcher

### DIFF
--- a/src/open_dread_rando/specific_patches/static_fixes.py
+++ b/src/open_dread_rando/specific_patches/static_fixes.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import construct
 from mercury_engine_data_structures.formats import Bmmap, Brfld
+from mercury_engine_data_structures.formats.dread_types import CDoorLifeComponent_SState
 from mercury_engine_data_structures.formats.gui_files import Bmscp
 
 from open_dread_rando.constants import ALL_SCENARIOS
@@ -364,7 +365,7 @@ def apply_experiment_fixes(editor: PatcherEditor):
 
     thermal_switch.pComponents.USABLE.vThermalDoors.append({
         "wpThermalDoor": magma.link_for_actor(new_name),
-        "sDoorState": 1
+        "sDoorState": CDoorLifeComponent_SState.Opened
     })
 
 

--- a/src/open_dread_rando/specific_patches/static_fixes.py
+++ b/src/open_dread_rando/specific_patches/static_fixes.py
@@ -357,19 +357,15 @@ def apply_experiment_fixes(editor: PatcherEditor):
     editor.copy_actor_groups("s020_magma", "trap_thermal_horizontal_004", new_name)
 
     # update thermal switch to open new door
-    thermal_switch = copy.deepcopy(editor.resolve_actor_reference({
+    thermal_switch = editor.resolve_actor_reference({
         "scenario": "s020_magma",
         "actor": "deviceheat"
-    }))
+    })
 
     thermal_switch.pComponents.USABLE.vThermalDoors.append({
         "wpThermalDoor": magma.link_for_actor(new_name),
         "sDoorState": 1
     })
-
-    magma.actors_for_layer('default')[thermal_switch.sName] = thermal_switch
-    for group in ["eg_collision_camera_004_Default", "eg_collision_camera_004_PostXRelease"]:
-        magma.add_actor_to_group(group, thermal_switch.sName)
 
 
 def apply_main_menu_fixes(editor: PatcherEditor):

--- a/src/open_dread_rando/specific_patches/static_fixes.py
+++ b/src/open_dread_rando/specific_patches/static_fixes.py
@@ -354,8 +354,7 @@ def apply_experiment_fixes(editor: PatcherEditor):
     new_door.vPos = (5840.0, -5455.0, 0.0)
 
     magma.actors_for_layer('default')[new_name] = new_door
-    for group in ["eg_collision_camera_004_Default", "eg_collision_camera_004_PostXRelease"]:
-        magma.add_actor_to_group(group, new_door.sName)
+    editor.copy_actor_groups("s020_magma", "trap_thermal_horizontal_004", new_name)
 
     # update thermal switch to open new door
     thermal_switch = copy.deepcopy(editor.resolve_actor_reference({

--- a/src/open_dread_rando/specific_patches/static_fixes.py
+++ b/src/open_dread_rando/specific_patches/static_fixes.py
@@ -342,6 +342,36 @@ def apply_experiment_fixes(editor: PatcherEditor):
         "actor": "trap_thermal_horizontal_POSTCOOL"
     }, "mapDoors")
 
+    # add thermal door in front of morph launcher
+    new_door = copy.deepcopy(editor.resolve_actor_reference({
+        "scenario": "s020_magma",
+        "actor": "trap_thermal_horizontal_004"
+    }))
+
+    new_name = "trap_thermal_horizontal_006"
+
+    new_door.sName = new_name
+    new_door.vPos = [5840.0, -5455.0, 0.0]
+
+    magma.actors_for_layer('default')[new_name] = new_door
+    for group in ["eg_collision_camera_004_Default", "eg_collision_camera_004_PostXRelease"]:
+        magma.add_actor_to_group(group, new_door.sName)
+
+    # update thermal switch to open new door
+    thermal_switch = copy.deepcopy(editor.resolve_actor_reference({
+        "scenario": "s020_magma",
+        "actor": "deviceheat"
+    }))
+
+    thermal_switch.pComponents.USABLE.vThermalDoors.append(construct.Container({
+        "wpThermalDoor": magma.link_for_actor(new_name),
+        "sDoorState": 1
+    }))
+
+    magma.actors_for_layer('default')[thermal_switch.sName] = thermal_switch
+    for group in ["eg_collision_camera_004_Default", "eg_collision_camera_004_PostXRelease"]:
+        magma.add_actor_to_group(group, thermal_switch.sName)
+
 
 def apply_main_menu_fixes(editor: PatcherEditor):
     extras = editor.get_file("gui/scripts/extrasmenucomposition.bmscp", Bmscp)

--- a/src/open_dread_rando/specific_patches/static_fixes.py
+++ b/src/open_dread_rando/specific_patches/static_fixes.py
@@ -363,10 +363,10 @@ def apply_experiment_fixes(editor: PatcherEditor):
         "actor": "deviceheat"
     }))
 
-    thermal_switch.pComponents.USABLE.vThermalDoors.append(construct.Container({
+    thermal_switch.pComponents.USABLE.vThermalDoors.append({
         "wpThermalDoor": magma.link_for_actor(new_name),
         "sDoorState": 1
-    }))
+    })
 
     magma.actors_for_layer('default')[thermal_switch.sName] = thermal_switch
     for group in ["eg_collision_camera_004_Default", "eg_collision_camera_004_PostXRelease"]:

--- a/src/open_dread_rando/specific_patches/static_fixes.py
+++ b/src/open_dread_rando/specific_patches/static_fixes.py
@@ -351,7 +351,7 @@ def apply_experiment_fixes(editor: PatcherEditor):
     new_name = "trap_thermal_horizontal_006"
 
     new_door.sName = new_name
-    new_door.vPos = [5840.0, -5455.0, 0.0]
+    new_door.vPos = (5840.0, -5455.0, 0.0)
 
     magma.actors_for_layer('default')[new_name] = new_door
     for group in ["eg_collision_camera_004_Default", "eg_collision_camera_004_PostXRelease"]:


### PR DESCRIPTION
As titled, this adds a thermal door before the morph launcher to Z-57. It's opened by the nearby thermal, preventing the player from softlocking by entering the arena with the thermals closed. 

![Metroid Dread_2024-04-15_16-54-10](https://github.com/randovania/open-dread-rando/assets/44988681/d5d86505-7b6c-44f9-b62b-f3ec95659479)