### PR TITLE
Don't set cooldown flag before Z-57

### DIFF
--- a/src/open_dread_rando/files/levels/s020_magma.lc.lua
+++ b/src/open_dread_rando/files/levels/s020_magma.lc.lua
@@ -782,7 +782,6 @@ end
 
 
 function s020_magma.SetCooldown(state)
-  Game.SetCooldownFlag(state)
   if state then
     Game.PushSetup("Cooldown", true, true)
   else


### PR DESCRIPTION
Z-57 doesn't actually need the cooldown flag set to spawn, so removing it prevents softlocks/getting blocked by the thermal doors snapping shut.