### PR TITLE
added map icons to new actors

### DIFF
--- a/src/open_dread_rando/specific_patches/objective.py
+++ b/src/open_dread_rando/specific_patches/objective.py
@@ -55,6 +55,13 @@ def apply_objective_patches(editor: PatcherEditor, configuration: dict):
     on_exit.vLogicActions[0].sCallback = "CurrentScenario.OnExit_AP_10"
     trigger.lstActivationConditions.append(on_exit)
 
+    # add minimap icon
+    ap_icon = copy.deepcopy(editor.get_scenario_map("s080_shipyard").get_category("mapUsables")["accesspoint_000"])
+    ap_icon.vPos = [c + offset for c, offset in zip(ap_icon.vPos, new_origin)]
+    ap_icon.oBox.Min = [p + offset for p, offset in zip(new_origin, (-150, 0))]
+    ap_icon.oBox.Max = [p + offset for p, offset in zip(new_origin, (150, 300))]
+    editor.get_scenario_map("s090_skybase").get_category("mapUsables")["accesspoint_000"] = ap_icon
+
     # increase the height of the trigger to prevent jumping over it
     segments = ap_trigger.pComponents.LOGICSHAPE.pLogicShape.oPolyCollection.vPolys[0].oSegmentData
     for i in range(2):

--- a/src/open_dread_rando/specific_patches/static_fixes.py
+++ b/src/open_dread_rando/specific_patches/static_fixes.py
@@ -293,6 +293,7 @@ def patch_corpius_checkpoints(editor: PatcherEditor):
 
 def apply_experiment_fixes(editor: PatcherEditor):
     magma = editor.get_scenario("s020_magma")
+    magma_map = editor.get_scenario_map("s020_magma")
 
     _apply_boss_cutscene_fixes(editor, {
         "scenario": "s020_magma",
@@ -356,6 +357,13 @@ def apply_experiment_fixes(editor: PatcherEditor):
 
     magma.actors_for_layer('default')[new_name] = new_door
     editor.copy_actor_groups("s020_magma", "trap_thermal_horizontal_004", new_name)
+
+    # update the minimap
+    new_map_icon = copy.deepcopy(magma_map.get_category("mapDoors")["trap_thermal_horizontal_004"])
+    new_map_icon.vPos = new_door.vPos[:2]
+    new_map_icon.oBoxL.Min = [c + offset for c, offset in zip(new_door.vPos, (-200.0, -50.0))]
+    new_map_icon.oBoxL.Max = [c + offset for c, offset in zip(new_door.vPos, (200.0, 50.0))]
+    magma_map.get_category("mapDoors")["trap_thermal_horizontal_006"] = new_map_icon
 
     # update thermal switch to open new door
     thermal_switch = editor.resolve_actor_reference({


### PR DESCRIPTION
fixes #324

- added a navigation station icon to the new station in itorash

![image](https://github.com/randovania/open-dread-rando/assets/25016775/28a9e0c6-0671-41a0-9ad8-0c3d46100edc)

- added a thermal gate icon to the new thermal gate in cataris before experiment

![image](https://github.com/randovania/open-dread-rando/assets/25016775/c6a29224-e8bf-4137-83b3-cd580478255e)

- the thermal gate is typically used in a smaller area so it doesn't quite fit the gap. can't find a way to fix it, would probably need to add a new map icon which isn't worth the space. 