### PR TITLE
Fix Artaria intro room "long load"

### DIFF
--- a/src/open_dread_rando/files/templates/custom_init.lua
+++ b/src/open_dread_rando/files/templates/custom_init.lua
@@ -2,7 +2,7 @@ Game.ImportLibrary("system/scripts/init_original.lua")
 
 local initOk, errorMsg = pcall(function()
 
-RemoteLua = RemoteLua or { 
+RemoteLua = RemoteLua or {
     -- defined by exlaunch
     Init = function() end,
     Update = function() end,
@@ -75,6 +75,15 @@ Init.tMaxGameProgressStats = {
     NumTanksPickedUp = 149
 }
 
+local preViewedCutscenes = {
+    "CutScenePlayed[cutscenes/0001gameintro_arrivalatrium/0001gameintro_arrivalatrium.bmscu]",
+    "CutScenePlayed[cutscenes/0001gameintro_fight/0001gameintro_fight.bmscu]",
+    "CutScenePlayed[cutscenes/0001gameintro_flashbackend/0001gameintro_flashbackend.bmscu]",
+    "CutScenePlayed[cutscenes/0001gameintro_flashbackinit/0001gameintro_flashbackinit.bmscu]",
+    "CutScenePlayed[cutscenes/0001gameintro_space/0001gameintro_space.bmscu]",
+    "CutScenePlayed[cutscenes/0001gameintrolanding/0001gameintrolanding.bmscu]",
+}
+
 function Game.StartPrologue(arg1, arg2, arg3, arg4, arg5)
     Game.LogWarn(0, string.format("Will start Game - %s / %s / %s / %s", tostring(arg1), tostring(arg2), tostring(arg3), tostring(arg4)))
     Game.LoadScenario("c10_samus", Init.sStartingScenario, Init.sStartingActor, "", 1)
@@ -91,12 +100,9 @@ function Init.CreateNewGameData(difficulty)
     original_Init_CreateNewGameData(difficulty)
 
     -- Mark the intro cutscenes as already played so that the intro room doesn't try to load the cutscene data
-    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_arrivalatrium/0001gameintro_arrivalatrium.bmscu]", "i", 1)
-    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_fight/0001gameintro_fight.bmscu]", "i", 1)
-    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_flashbackend/0001gameintro_flashbackend.bmscu]", "i", 1)
-    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_flashbackinit/0001gameintro_flashbackinit.bmscu]", "i", 1)
-    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_space/0001gameintro_space.bmscu]", "i", 1)
-    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintrolanding/0001gameintrolanding.bmscu]", "i", 1)
+    for _, cutscene in ipairs(preViewedCutscenes) do
+        Blackboard.SetProp("PlayedCutscenes", cutscene, "i", 1)
+    end
 
     local playerSection =  Game.GetPlayerBlackboardSectionName()
 

--- a/src/open_dread_rando/files/templates/custom_init.lua
+++ b/src/open_dread_rando/files/templates/custom_init.lua
@@ -90,6 +90,14 @@ local original_Init_CreateNewGameData = Init.CreateNewGameData
 function Init.CreateNewGameData(difficulty)
     original_Init_CreateNewGameData(difficulty)
 
+    -- Mark the intro cutscenes as already played so that the intro room doesn't try to load the cutscene data
+    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_arrivalatrium/0001gameintro_arrivalatrium.bmscu]", "i", 1)
+    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_fight/0001gameintro_fight.bmscu]", "i", 1)
+    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_flashbackend/0001gameintro_flashbackend.bmscu]", "i", 1)
+    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_flashbackinit/0001gameintro_flashbackinit.bmscu]", "i", 1)
+    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintro_space/0001gameintro_space.bmscu]", "i", 1)
+    Blackboard.SetProp("PlayedCutscenes", "CutScenePlayed[cutscenes/0001gameintrolanding/0001gameintrolanding.bmscu]", "i", 1)
+
     local playerSection =  Game.GetPlayerBlackboardSectionName()
 
     --[[


### PR DESCRIPTION
By marking all of the intro cutscenes as "already played" when a new file is created, it seems to stop the cutscene players from doing whatever it is they do that causes a "long load" whenever the player walks into the Intro Room.

I plan on doing some stress testing to ensure that this does in fact fix the intro room _crashes_ as well, but my initial thought is that it _should_ fix those crashes since the room transition seems to be a normal room transition now.