### PR TITLE
Allow starting with any amount of eparts regardless of configuration

### DIFF
--- a/src/open_dread_rando/dread_patcher.py
+++ b/src/open_dread_rando/dread_patcher.py
@@ -60,10 +60,11 @@ def create_custom_init(editor: PatcherEditor, configuration: dict) -> str:
     if "ITEM_LIFE_SHARDS" in inventory and inventory["ITEM_LIFE_SHARDS"] > 0:
         total_shards = inventory["ITEM_LIFE_SHARDS"]
         leftover_shards = total_shards % 4
-        max_life += (total_shards - leftover_shards) * energy_per_part
         if configuration["immediate_energy_parts"] or leftover_shards == 0:
+            max_life += total_shards * energy_per_part
             inventory.pop("ITEM_LIFE_SHARDS")
-        else:
+        elif total_shards > leftover_shards:
+            max_life += (total_shards - leftover_shards) * energy_per_part
             inventory["ITEM_LIFE_SHARDS"] = leftover_shards
 
     inventory.update({

--- a/src/open_dread_rando/dread_patcher.py
+++ b/src/open_dread_rando/dread_patcher.py
@@ -57,9 +57,14 @@ def create_custom_init(editor: PatcherEditor, configuration: dict) -> str:
     if "ITEM_ENERGY_TANKS" in inventory:
         etanks = inventory.pop("ITEM_ENERGY_TANKS")
         max_life += etanks * energy_per_tank
-    if "ITEM_LIFE_SHARDS" in inventory and configuration["immediate_energy_parts"]:
-        shards = inventory.pop("ITEM_LIFE_SHARDS")
-        max_life += shards * energy_per_part
+    if "ITEM_LIFE_SHARDS" in inventory:
+        total_shards = inventory.pop("ITEM_LIFE_SHARDS")
+        leftover_shards = total_shards % 4
+        if configuration["immediate_energy_parts"] or leftover_shards == 0:
+            max_life += total_shards * energy_per_part
+        else:
+            inventory["ITEM_LIFE_SHARDS"] = leftover_shards
+            max_life += (total_shards - leftover_shards) * energy_per_part
 
     inventory.update({
         # TODO: expose shuffling these

--- a/src/open_dread_rando/dread_patcher.py
+++ b/src/open_dread_rando/dread_patcher.py
@@ -57,14 +57,14 @@ def create_custom_init(editor: PatcherEditor, configuration: dict) -> str:
     if "ITEM_ENERGY_TANKS" in inventory:
         etanks = inventory.pop("ITEM_ENERGY_TANKS")
         max_life += etanks * energy_per_tank
-    if "ITEM_LIFE_SHARDS" in inventory:
-        total_shards = inventory.pop("ITEM_LIFE_SHARDS")
+    if "ITEM_LIFE_SHARDS" in inventory and inventory["ITEM_LIFE_SHARDS"] > 0:
+        total_shards = inventory["ITEM_LIFE_SHARDS"]
         leftover_shards = total_shards % 4
+        max_life += (total_shards - leftover_shards) * energy_per_part
         if configuration["immediate_energy_parts"] or leftover_shards == 0:
-            max_life += total_shards * energy_per_part
+            inventory.pop("ITEM_LIFE_SHARDS")
         else:
             inventory["ITEM_LIFE_SHARDS"] = leftover_shards
-            max_life += (total_shards - leftover_shards) * energy_per_part
 
     inventory.update({
         # TODO: expose shuffling these

--- a/src/open_dread_rando/files/schema.json
+++ b/src/open_dread_rando/files/schema.json
@@ -251,9 +251,6 @@
         },
         "starting_items": {
             "type": "object",
-            "properties": {
-                "ITEM_LIFE_SHARDS": {"type": "number", "maximum": 3}
-            },
             "propertyNames": {
                 "$ref": "#/$defs/item_id"
             }

--- a/tests/test_files/april_fools_patcher.json
+++ b/tests/test_files/april_fools_patcher.json
@@ -15,7 +15,8 @@
         "ITEM_RANDO_ARTIFACT_9": 1,
         "ITEM_RANDO_ARTIFACT_10": 1,
         "ITEM_RANDO_ARTIFACT_11": 1,
-        "ITEM_RANDO_ARTIFACT_12": 1
+        "ITEM_RANDO_ARTIFACT_12": 1,
+        "ITEM_LIFE_SHARDS": 7
     },
     "starting_text": [
         []
@@ -4057,7 +4058,7 @@
         }
     },
     "energy_per_tank": 100,
-    "immediate_energy_parts": true,
+    "immediate_energy_parts": false,
     "enable_remote_lua": true,
     "constant_environment_damage": {
         "heat": 20,


### PR DESCRIPTION
Regardless if `immediate_energy_parts` is enabled or not, the proper amount of starting energy and leftover parts will be applied.

Fixes https://github.com/randovania/randovania/issues/6930