### PR TITLE
Change minimum Speed Booster charge time

### DIFF
--- a/src/open_dread_rando/files/randomizer_powerup.lua
+++ b/src/open_dread_rando/files/randomizer_powerup.lua
@@ -262,7 +262,9 @@ local tItemTunableHandlers = {
     end,
     ["ITEM_UPGRADE_SPEED_BOOST_CHARGE"] = function(quantity)
         -- Amount of time in seconds for SB to charge - vanilla is 1.5 seconds. Each upgrade reduces by 0.25 seconds.
-        local chargeTime = math.max(0.25, 1.5 - quantity * 0.25)
+        -- Cannot be <= 0 or else all hell breaks loose.
+        -- SB activation is very buggy <= 0.5, so we clamp it a tiny bit higher.
+        local chargeTime = math.max(0.55, 1.5 - quantity * 0.25)
         Scenario.SetTunableValue("CTunableAbilitySpeedBooster", "fTimeToActivate", chargeTime)
     end
 }


### PR DESCRIPTION
There is a well-known quirk when you have four or more Speed Booster Upgrades that causes Speed Booster to sometimes fail to activate when buffering it while Samus turns around. Bumping the minimum charge time up to 0.55 seconds seems to fix this in all of my testing, and there's nowhere in logic that requires >= 4 upgrades, so this shouldn't have any logical implications at all. The "effective" maximum number of upgrades you can collect is now 4 instead of 5, but 5 was even buggier than 4 was, so I don't think this is a bad thing.