### PR TITLE
Change Omega Blaster item to Power Beam

### DIFF
--- a/src/open_dread_rando/pickups/split_pickups.py
+++ b/src/open_dread_rando/pickups/split_pickups.py
@@ -460,6 +460,8 @@ def _patch_split_missiles(editor: PatcherEditor) -> list[ActorDefFunc]:
 
     lockon.main_inventory_item = "ITEM_WEAPON_STORM_MISSILE"
 
+    omega.main_inventory_item = "ITEM_WEAPON_POWER_BEAM"
+
     return [gun.raw for gun in [
         missile,
         solo_super,


### PR DESCRIPTION
Fixes a crash when trying to fire Proto's Omega Blaster with 0 max missiles