### PR TITLE
Implement seed-based save slots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "mercury-engine-data-structures>=0.33",
+    "mercury-engine-data-structures==0.35.0",
     "jsonschema>=4.0.0",
     "json-delta>=2.0.2",
-    "open-dread-rando-exlaunch>=1.2.0"
+    "open-dread-rando-exlaunch>=1.3.0"
 ]
 dynamic = ["version"]
 

--- a/src/open_dread_rando/dread_patcher.py
+++ b/src/open_dread_rando/dread_patcher.py
@@ -213,8 +213,8 @@ def validate(configuration: dict):
 def patch_saveslot(editor: PatcherEditor, configuration: dict):
     if not configuration["cosmetic_patches"]["split_saves"]:
         return
-    
-    save_key = f"RDV_{configuration["configuration_identifier"]}_{configuration["layout_uuid"]}"
+
+    save_key = f"RDV_{configuration['configuration_identifier']}_{configuration['layout_uuid']}"
     editor.add_new_asset("RDVHASH", save_key.encode("ascii"), in_pkgs=[])
 
 

--- a/src/open_dread_rando/dread_patcher.py
+++ b/src/open_dread_rando/dread_patcher.py
@@ -215,7 +215,7 @@ def patch_saveslot(editor: PatcherEditor, configuration: dict):
         return
     
     save_key = f"RDV_{configuration["configuration_identifier"]}_{configuration["layout_uuid"]}"
-    editor.add_new_asset("RDVHASH", bytes(save_key, encoding="ascii"), in_pkgs=[])
+    editor.add_new_asset("RDVHASH", save_key.encode("ascii"), in_pkgs=[])
 
 
 def apply_patches(editor: PatcherEditor, lua_editor: LuaEditor, configuration: dict):

--- a/src/open_dread_rando/dread_patcher.py
+++ b/src/open_dread_rando/dread_patcher.py
@@ -213,8 +213,8 @@ def validate(configuration: dict):
 def patch_saveslot(editor: PatcherEditor, configuration: dict):
     if not configuration["cosmetic_patches"]["split_saves"]:
         return
-    
-    save_key = f"RDV_{configuration["configuration_identifier"]}_{configuration["layout_uuid"]}"
+
+    save_key = f"RDV_{configuration['configuration_identifier']}_{configuration['layout_uuid']}"
     editor.add_new_asset("RDVHASH", bytes(save_key, encoding="ascii"), in_pkgs=[])
 
 
@@ -299,6 +299,7 @@ def apply_patches(editor: PatcherEditor, lua_editor: LuaEditor, configuration: d
 
     # saveslot patches
     patch_saveslot(editor, configuration)
+
 
 def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     LOG.info("Will patch files from %s", input_path)

--- a/src/open_dread_rando/dread_patcher.py
+++ b/src/open_dread_rando/dread_patcher.py
@@ -210,6 +210,14 @@ def validate(configuration: dict):
     DefaultValidatingDraft7Validator(_read_schema()).validate(configuration)
 
 
+def patch_saveslot(editor: PatcherEditor, configuration: dict):
+    if not configuration["cosmetic_patches"]["split_saves"]:
+        return
+    
+    save_key = f"RDV_{configuration["configuration_identifier"]}_{configuration["layout_uuid"]}"
+    editor.add_new_asset("RDVHASH", bytes(save_key, encoding="ascii"), in_pkgs=[])
+
+
 def apply_patches(editor: PatcherEditor, lua_editor: LuaEditor, configuration: dict):
     # Copy custom files
     add_custom_files(editor)
@@ -289,6 +297,8 @@ def apply_patches(editor: PatcherEditor, lua_editor: LuaEditor, configuration: d
     # remote connector disconnect symbol
     patch_sprites(editor)
 
+    # saveslot patches
+    patch_saveslot(editor, configuration)
 
 def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     LOG.info("Will patch files from %s", input_path)

--- a/src/open_dread_rando/files/schema.json
+++ b/src/open_dread_rando/files/schema.json
@@ -431,6 +431,11 @@
                             "default": "DEFAULT"
                         }
                     }
+                },
+                "split_saves": {
+                    "description": "When enabled, names save slots after seed's GUID",
+                    "type": "boolean",
+                    "default": false
                 }
             },
             "required": [

--- a/tests/test_files/patcher_files/advanced_patcher.json
+++ b/tests/test_files/patcher_files/advanced_patcher.json
@@ -3495,7 +3495,8 @@
         "lua": {
             "custom_init": {}
         },
-        "shield_versions": {}
+        "shield_versions": {},
+        "split_saves": false
     },
     "tunables": {
         "AbilityOpticCamouflage": {

--- a/tests/test_files/patcher_files/starter_preset_patcher.json
+++ b/tests/test_files/patcher_files/starter_preset_patcher.json
@@ -3935,7 +3935,8 @@
             "bomb": "ALTERNATE",
             "cross_bomb": "ALTERNATE",
             "power_bomb": "DEFAULT"
-        }
+        },
+        "split_saves": true
     },
     "energy_per_tank": 100,
     "immediate_energy_parts": true,

--- a/tests/test_full_patch.py
+++ b/tests/test_full_patch.py
@@ -35,6 +35,6 @@ def test_export(dread_path, tmp_path, test_files_dir, configuration_path):
     if configuration["cosmetic_patches"]["split_saves"]:
         assert profile_path.exists()
         profile_name = profile_path.read_text()
-        assert profile_name == f"RDV_{configuration["configuration_identifier"]}_{configuration["layout_uuid"]}"
+        assert profile_name == f"RDV_{configuration['configuration_identifier']}_{configuration['layout_uuid']}"
     else:
         assert not profile_path.exists()

--- a/tests/test_full_patch.py
+++ b/tests/test_full_patch.py
@@ -8,7 +8,7 @@ configuration_jsons = [x for x in Path(__file__).parent.joinpath("test_files", "
 
 @pytest.mark.parametrize("configuration_path", configuration_jsons)
 def test_export(dread_path, tmp_path, test_files_dir, configuration_path):
-    output_path = tmp_path.joinpath("out")
+    output_path: Path = tmp_path.joinpath("out")
     configuration = test_files_dir.read_json(configuration_path)
 
     dread_patcher.patch_extracted(
@@ -30,3 +30,11 @@ def test_export(dread_path, tmp_path, test_files_dir, configuration_path):
         "DreadRandovania/exefs/main.npdm",
         "DreadRandovania/exefs/subsdk9",
     ]
+
+    profile_path = output_path.joinpath("DreadRandovania", "romfs", "RDVHASH")
+    if configuration["cosmetic_patches"]["split_saves"]:
+        assert profile_path.exists()
+        profile_name = profile_path.read_text()
+        assert profile_name == f"RDV_{configuration["configuration_identifier"]}_{configuration["layout_uuid"]}"
+    else:
+        assert not profile_path.exists()


### PR DESCRIPTION
- Waiting on corresponding odr-exlaunch patch
- Adds a patcher option configuration.cosmetic_options.split_saves
  - bool, default false
- If this is true, generates a file "romfs:/RDVHASH" with a cstring "RDV_(Seed Identifier)_(Layout UUID)"
- Exlaunch uses this file to store saves 1/2/3 in separate slots than the "profile0/1/2" folders
- Added tests to ensure valid export for split_saves being missing, false or true